### PR TITLE
Backend asyncio game ending with test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ sql_app.db
 ignore/
 alembic/
 alembic.ini
+setupProxy.js
 
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ quit error: 이미 플레이 중이거나 게임이 종료된 방에서 나가�
 
 #### 게임 시작(start)
 
-프론트엔드에서 대기 방 화면에 있는 동안 admin 등의 누군가가 다음을 요청하여 방 상태를 플레이 중인 방으로 변경
+프론트엔드에서 대기 방 화면에 있는 동안 admin 권한을 가진 사람이 다음을 요청하여 방 상태를 플레이 중인 방으로 변경
 ```
 let request = {
   request: "start",
@@ -182,6 +182,16 @@ let request = {
   time_duration: 60  // seconds, 처음 손을 입력받기 시작한 후 손을 입력받는 시간대의 길이
 };
 ws.send(request);
+```
+
+start error: admin 권한이 없는 사람이 게임 시작 요청을 보낸 경우 아래 메시지 응답
+```
+{
+  request: "start",
+  response: "error",
+  type: "message",
+  message: "Forbidden"
+}
 ```
 
 start error: 이미 플레이 중인 방이거나 게임이 종료된 방에서 게임을 시작하려 하는 경우 아래 메시지 응답
@@ -256,13 +266,20 @@ start error: 이미 플레이 중인 방이거나 게임이 종료된 방에서 
 }
 ```
 
-**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환된 후에 `time_offset`초가 지나 손 입력을 받기 시작하는 순간이 되면 해당 방의 모든 사람들에게 아래 메시지 응답
+**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환된 후에 `time_offset`초가 지나 손 입력을 받기 시작하는 순간이 되면 해당 방의 모든 사람들에게 백엔드 서버의 `start_time`이 포함된 아래 정보 응답
 ```
 {
   request: "start",
   response: "broadcast",
-  type: "message",
-  message: "Game start"
+  type: "room_start",
+  data: {
+    state: 1,                                     // Play
+    time_offset : 5,
+    time_duration : 60,
+    init_time: "2022-12-25 03:24:00.388157 KST",  // 한국 시간 기준
+    start_time: "2022-12-25 03:24:05.391465 KST", // 이 시간을 기준으로 남은 시간을 프론트엔드에서 표시하면 됨!
+    end_time: ""                                  // 아직 빈 문자열로 반환
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,30 @@ hand error: 방이 플레이 중인 방이지만 손 입력 가능 시간이 초
 
 #### 게임 종료(end)
 
-* **end broadcast**: 프론트엔드에서 요청하지 않아도, 플레이 중인 방에서 손 입력 시간이 종료되는 경우 서버에서 먼저 해당 방의 모든 사람들에게 다음 정보 응답
+* **end broadcast**: 프론트엔드에서 요청하지 않아도, 플레이 중인 방에서 손 입력 시간이 종료되는 경우 서버에서 먼저 해당 방의 모든 사람들에게 다음의 손 목록 정보 응답
+```
+{
+  request: "end",
+  response: "broadcast",
+  type: "hand_list",
+  data: [
+    {
+      affiliation: "소속",
+      name: "이름",
+      hand: 0,    // 0(Rock) 또는 1(Scissor) 또는 2(Paper)
+      score: 1,   // 1(이김) 또는 0(비김) 또는 -1(짐)
+      time: "2022-12-25 03:25:04.510891 KST",
+      room_id: 1
+    },
+    ...  // 해당 방에서 입력된 손 개수만큼 존재
+  ]
+}
+```
+* 가장 마지막에 입력된 손이 목록의 인덱스 0번에 위치한다.
+* *결과 화면에, 여기서 받은 "hand_list" 정보를 바탕으로 csv 등의 파일로 결과를 export하는 기능도 추가되면 좋겠다.*
+  * *"game_list"를 csv로 export하는 버튼 바로 위에 새 버튼을 만들어 "hand_list"를 csv로 export하도록 하면 되겠다.*
+
+* **end broadcast**: 프론트엔드에서 요청하지 않아도, 플레이 중인 방에서 손 입력 시간이 종료되는 경우 서버에서 먼저 해당 방의 모든 사람들에게 다음의 전적 정보 응답
 ```
 {
   request: "end",
@@ -403,7 +426,6 @@ hand error: 방이 플레이 중인 방이지만 손 입력 가능 시간이 초
 * 가장 순위가 높은 사람(1)이 목록의 인덱스 0번에 위치한다.
 * 이 응답을 받은 이후에는 손 입력을 받지 않고, 해당 방에서의 게임이 종료된다.
 * 프론트엔드에서는 이 응답을 받고 나서 3초 정도 후에 결과 화면을 보여주고, 결과 화면에서 "나가기" 버튼을 눌러 입장 전 화면으로 이동하면 된다.
-  * *결과 화면에서는 여기서 받은 "game_list" 정보를 바탕으로 csv 등의 파일로 결과를 export하는 기능이 있으면 좋겠다.*
   * *입장 전 화면에서는 기존에 접속했던 계정(소속 및 이름) 정보가 그대로 입력 필드에 차 있어서 "입장!" 버튼만 누르면 바로 다시 입장할 수 있도록 하면 좋겠다.*
 
 #### 연결 끊김(disconnected)
@@ -562,7 +584,7 @@ disconnect broadcast: 요청 데이터에 필요한 정보가 모두 들어있�
 ##### Test 2
 * start 요청을 통해 대기 방에서 플레이 중인 방으로 전환하기: 성공
 * start 직후에 hand 요청을 날리고 오류 메시지 받기: 성공
-* start 후 5초 후에 손 입력을 받기 시작한다는 메시지 받기: 성공
+* start 후 3초 후에 손 입력을 받기 시작한다는 메시지 받기: 성공
 * 손 입력을 받기 시작한 후 2초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
 * 손 입력을 받기 시작한 후 5초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
 * 손 입력을 받기 시작한 후 7초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
@@ -575,62 +597,76 @@ disconnect broadcast: 요청 데이터에 필요한 정보가 모두 들어있�
 * 대기 방에서 start 요청을 `time_offset`과 `time_duration` 없이 날리고 서버에 의해 연결 끊기기: 성공
 * 서버에 의해 연결이 끊겨도 이후에 같은 소속과 이름의 계정으로 새로운 방에 들어갈 수 있음: 확인
 
+##### Test 4
+* 관리자 권한이 없는 계정으로 입장한 후 start 요청을 날리고 "Forbidden" 오류 응답 받기: 성공
+
 #### 테스트하지 않은 항목
 * 여러 명이 동시에 한 방에 들어가고 나가고 연결이 끊기는 상황
-* 여러 방에서 동시에 게임이 돌아가는 상황
+* 여러 방에서 동시에 게임이 돌아가는 상황 -> 당장은 고려하지 않을 것
 * 플레이 중인 방에서 연결이 끊겼을 때 다시 입장하려는 상황 -> 아직 구현이 안 되어 있지만 기존의 방이 아직 플레이 중인 상태라면 그 방으로 재입장하도록 구현할 예정
 
 #### 테스트 로그
+* `cd {root_of_this_repository}`
+* `./sql_app/Scripts/Activate.ps1` (가상환경 실행)
 * `python ./backend_websocket_test.py`
 
 ```
 ----------------- Test 1: join and quit -----------------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'room_id': 10, 'person_id': 3}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 10}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'room_id': 6, 'person_id': 1}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 6}]}
 @@ send quit
 {'request': 'quit', 'response': 'success', 'type': 'message', 'message': 'Successfully signed out'}
 
 ------------ Test 2: join and start and hand ------------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'room_id': 10, 'person_id': 13}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 10}]}
-@@ send start 5 10
-{'request': 'start', 'response': 'broadcast', 'type': 'room', 'data': {'state': 1, 'time_offset': 5, 'time_duration': 10, 'init_time': '2022-12-30 13:28:35.399589 KST', 'start_time': '', 'end_time': ''}}
-{'request': 'start', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
-{'request': 'start', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 10}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'room_id': 6, 'person_id': 2}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 6}]}
+@@ send start 3 10
+{'request': 'start', 'response': 'broadcast', 'type': 'room', 'data': {'state': 1, 'time_offset': 3, 'time_duration': 10, 'init_time': '2023-01-02 13:21:59.199722 KST', 'start_time': '', 'end_time': ''}}
+{'request': 'start', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}  
+{'request': 'start', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 6}]}
 @@@ send hand 0 -> error response
 {'request': 'hand', 'response': 'error', 'type': 'message', 'message': 'Game not started yet'}
 @@@@ start response
-{'request': 'start', 'response': 'broadcast', 'type': 'message', 'message': 'Game start'}
+{'request': 'start', 'response': 'broadcast', 'type': 'room_start', 'data': {'state': 1, 'time_offset': 3, 'time_duration': 10, 'init_time': '2023-01-02 13:21:59.199722 KST', 'start_time': '2023-01-02 13:21:59.199722 KST', 'end_time': ''}}
 @@@@@ send hand 0
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': -1, 'time': '2022-12-30 13:28:42.499772 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -1, 'win': 0, 'draw': 0, 'lose': 1, 'room_id': 10}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 1, 'lose': 0, 'room_id': 6}]}
 @@@@@@ send hand 1 -> lose
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 1, 'score': -1, 'time': '2022-12-30 13:28:45.537418 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': -1, 'time': '2022-12-30 13:28:42.499772 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -2, 'win': 0, 'draw': 0, 'lose': 2, 'room_id': 10}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-02 13:22:07.337083 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': -1, 'win': 0, 'draw': 1, 'lose': 1, 'room_id': 6}]}
 @@@@@@@ send hand 0 -> win
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': 1, 'time': '2022-12-30 13:28:47.581427 KST', 'room_id': 10}, {'affiliation': 'STAFF', 
-'name': '2022-12-30 13:28:35.363117', 'hand': 1, 'score': -1, 'time': '2022-12-30 13:28:45.537418 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': -1, 'time': '2022-12-30 13:28:42.499772 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 10}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 1, 'time': '2023-01-02 13:22:09.378423 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-02 13:22:07.337083 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 1, 'draw': 1, 'lose': 1, 'room_id': 6}]}
 @@@@@@@@ end response
-{'request': 'end', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 10}]}
+{'request': 'end', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 1, 'time': '2023-01-02 13:22:09.378423 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-02 13:22:07.337083 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
+{'request': 'end', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 1, 'draw': 1, 'lose': 1, 'room_id': 6}]}
 @@@@@@@@@ send hand 0 -> not connected
 
 --------- Test 3: join and error and disconnect ---------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 11, 'person_id': 2}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 11}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 7, 'person_id': 3}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
 @@ send plain text (not a JSON)
 {'request': '', 'response': 'error', 'type': 'message', 'message': 'Bad request'}
 @@@ disconnected (without sending quit)
 @@@@ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 11, 'person_id': 2}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 11}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 7, 'person_id': 3}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
 @@@@@ send start (without required keyword arguments) -> disconnect
 {'state': 0, 'time_offset': -1, 'time_duration': -1, 'init_time': '', 'start_time': '', 'end_time': ''}
 @@@@@@ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 11, 'person_id': 2}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 11}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 7, 'person_id': 3}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
 @@@@@@@ disconnected (without sending quit)
+
+---------------- Test 4: forbidden start ----------------
+@ send join
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'UPnL', 'name': '아무개', 'is_admin': False, 'room_id': 7, 'person_id': 4}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'UPnL', 'name': '아무개', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
+@@ send start 3 10
+{'request': 'start', 'response': 'error', 'type': 'message', 'message': 'Forbidden'}
+@@@ send quit
+{'request': 'quit', 'response': 'success', 'type': 'message', 'message': 'Successfully signed out'}
 ```

--- a/README.md
+++ b/README.md
@@ -188,14 +188,19 @@ start error: 이미 플레이 중인 방이거나 게임이 종료된 방에서 
   response: "broadcast",
   type: "room",
   data: {
-    state: 1,  // Play
-    start_time: "2022-12-25 03:24:05.388157 KST",  // 한국 시간 기준
-    end_time: "2022-12-25 03:25:05.388157 KST"
+    state: 1,                                     // Play
+    time_offset : 5,                              // 이때는 항상 0 이상의 정수이지만 대기 방에서는 -1
+    time_duration : 60,                           // 이때는 항상 1 이상의 정수이지만 대기 방에서는 -1
+    init_time: "2022-12-25 03:24:00.388157 KST",  // 한국 시간 기준
+    start_time: "",                               // 아직 빈 문자열로 반환
+    end_time: ""                                  // 아직 빈 문자열로 반환
   }
 }
 ```
+* start_time: 실제로 손 입력을 받기 시작할 때(`message: "Game start"`라는 메시지를 서버가 응답할 때) 결정되므로 그 이후에 GET `/room/{room_id}` 하면 확인할 수 있음
+* end_time: 실제로 게임이 종료될 때(`response: "end"`인 정보를 서버가 응답할 때) 결정되므로 그 이후에 GET `/room/{room_id}` 하면 확인할 수 있음
 
-**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 첫 번째 랜덤 손이 포함된 손 목록 정보 응답
+**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 해당 방의 모든 사람들에게 첫 번째 랜덤 손이 포함된 손 목록 정보 응답
 ```
 {
   request: "start",
@@ -215,7 +220,7 @@ start error: 이미 플레이 중인 방이거나 게임이 종료된 방에서 
 ```
 * 첫 번째 랜덤 손은 이 방에 입장한 첫 번째 사람 명의로 표시되지만, 이 사람의 전적(score, win, draw, lose)에는 영향을 주지 않는다.
 
-**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 해당 방에서 플레이하게 되는 사람(전적) 목록 정보 응답
+**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 해당 방의 모든 사람들에게 해당 방에서 플레이하게 되는 사람(전적) 목록 정보 응답
 ```
 {
   request: "start",
@@ -235,6 +240,16 @@ start error: 이미 플레이 중인 방이거나 게임이 종료된 방에서 
     },
     ...  // 해당 방에서 플레이하는 사람 수만큼 존재
   ]
+}
+```
+
+**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환된 후에 `time_offset`초가 지나 손 입력을 받기 시작하는 순간이 되면 해당 방의 모든 사람들에게 아래 메시지 응답
+```
+{
+  request: "start",
+  response: "broadcast",
+  type: "message",
+  message: "Game start"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -205,67 +205,50 @@ start error: 이미 플레이 중인 방이거나 게임이 종료된 방에서 
 }
 ```
 
-**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 해당 방에서 손 입력을 받기 시작하는 시간(`start_time`)과 손 입력이 종료되는 시간(`end_time`)이 포함된 아래 정보 응답
+**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 해당 방에서 손 입력을 받기 시작하는 시간(`start_time`)과 손 입력이 종료되는 시간(`end_time`)이 포함된 `room`과, 첫 번째 랜덤 손이 포함된 손 목록(`hand_list`)과, 해당 방에서 플레이하게 되는 사람(전적) 목록(`game_list`)이 포함된 아래 정보 응답
 ```
 {
   request: "start",
   response: "broadcast",
-  type: "room",
+  type: "init_data",
   data: {
-    state: 1,                                     // Play
-    time_offset : 5,                              // 이때는 항상 0 이상의 정수이지만 대기 방에서는 -1
-    time_duration : 60,                           // 이때는 항상 1 이상의 정수이지만 대기 방에서는 -1
-    init_time: "2022-12-25 03:24:00.388157 KST",  // 한국 시간 기준
-    start_time: "",                               // 아직 빈 문자열로 반환
-    end_time: ""                                  // 아직 빈 문자열로 반환
-  }
+    room: {
+      state: 1,                                     // Play
+      time_offset : 5,                              // 이때는 항상 0 이상의 정수이지만 대기 방에서는 -1
+      time_duration : 60,                           // 이때는 항상 1 이상의 정수이지만 대기 방에서는 -1
+      init_time: "2022-12-25 03:24:00.388157 KST",  // 한국 시간 기준
+      start_time: "",                               // 아직 빈 문자열로 반환
+      end_time: ""                                  // 아직 빈 문자열로 반환
+    }, 
+    hand_list: [
+      {
+        affiliation: "소속",  // 이 방에 입장한 첫 번째 사람 소속
+        name: "이름",         // 이 방에 입장한 첫 번째 사람 이름
+        hand: 0,   // 0(Rock) 또는 1(Scissor) 또는 2(Paper) 중 랜덤으로 부여
+        score: 0,  // 첫 번째 손이므로 항상 비긴(0) 것으로 취급
+        time: "2022-12-25 03:24:00.388157 KST",
+        room_id: 1
+      }
+    ],
+    game_list: [
+      {
+        rank: 1,  // 초기 순위는 이 방에 입장한 첫 번째 사람이 1
+        affiliation: "소속",
+        name: "이름",
+        is_admin: False,
+        score: 0,
+        win: 0,
+        draw: 0,
+        lose: 0,
+        room_id: 1
+      },
+      ...  // 해당 방에서 플레이하는 사람 수만큼 존재
+    ]
 }
 ```
 * start_time: 실제로 손 입력을 받기 시작할 때(`message: "Game start"`라는 메시지를 서버가 응답할 때) 결정되므로 그 이후에 GET `/room/{room_id}` 하면 확인할 수 있음
 * end_time: 실제로 게임이 종료될 때(`response: "end"`인 정보를 서버가 응답할 때) 결정되므로 그 이후에 GET `/room/{room_id}` 하면 확인할 수 있음
-
-**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 해당 방의 모든 사람들에게 첫 번째 랜덤 손이 포함된 손 목록 정보 응답
-```
-{
-  request: "start",
-  response: "broadcast",
-  type: "hand_list",
-  data: [
-    {
-      affiliation: "소속",  // 이 방에 입장한 첫 번째 사람 소속
-      name: "이름",         // 이 방에 입장한 첫 번째 사람 이름
-      hand: 0,   // 0(Rock) 또는 1(Scissor) 또는 2(Paper) 중 랜덤으로 부여
-      score: 0,  // 첫 번째 손이므로 항상 비긴(0) 것으로 취급
-      time: "2022-12-25 03:24:00.388157 KST",
-      room_id: 1
-    }
-  ]
-}
-```
 * 첫 번째 랜덤 손은 이 방에 입장한 첫 번째 사람 명의로 표시되지만, 이 사람의 전적(score, win, draw, lose)에는 영향을 주지 않는다.
-
-**start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환되면 해당 방의 모든 사람들에게 해당 방에서 플레이하게 되는 사람(전적) 목록 정보 응답
-```
-{
-  request: "start",
-  response: "broadcast",
-  type: "game_list",
-  data: [
-    {
-      rank: 1,  // 초기 순위는 이 방에 입장한 첫 번째 사람이 1
-      affiliation: "소속",
-      name: "이름",
-      is_admin: False,
-      score: 0,
-      win: 0,
-      draw: 0,
-      lose: 0,
-      room_id: 1
-    },
-    ...  // 해당 방에서 플레이하는 사람 수만큼 존재
-  ]
-}
-```
 
 **start broadcast**: 방이 성공적으로 플레이 중인 상태로 전환된 후에 `time_offset`초가 지나 손 입력을 받기 시작하는 순간이 되면 해당 방의 모든 사람들에게 백엔드 서버의 `start_time`이 포함된 아래 정보 응답
 ```
@@ -613,58 +596,56 @@ disconnect broadcast: 요청 데이터에 필요한 정보가 모두 들어있�
 ```
 ----------------- Test 1: join and quit -----------------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'room_id': 6, 'person_id': 1}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 6}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'room_id': 8, 'person_id': 1}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 8}]}
 @@ send quit
 {'request': 'quit', 'response': 'success', 'type': 'message', 'message': 'Successfully signed out'}
 
 ------------ Test 2: join and start and hand ------------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'room_id': 6, 'person_id': 2}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 6}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'room_id': 8, 'person_id': 2}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 8}]}
 @@ send start 3 10
-{'request': 'start', 'response': 'broadcast', 'type': 'room', 'data': {'state': 1, 'time_offset': 3, 'time_duration': 10, 'init_time': '2023-01-02 13:21:59.199722 KST', 'start_time': '', 'end_time': ''}}
-{'request': 'start', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}  
-{'request': 'start', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 6}]}
+{'request': 'start', 'response': 'broadcast', 'type': 'init_data', 'data': {'room': {'state': 1, 'time_offset': 3, 'time_duration': 10, 'init_time': '2023-01-03 17:52:37.710706 KST', 'start_time': '', 'end_time': ''}, 'hand_list': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:37.710706 KST', 'room_id': 8}], 'game_list': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 8}]}}
 @@@ send hand 0 -> error response
 {'request': 'hand', 'response': 'error', 'type': 'message', 'message': 'Game not started yet'}
 @@@@ start response
-{'request': 'start', 'response': 'broadcast', 'type': 'room_start', 'data': {'state': 1, 'time_offset': 3, 'time_duration': 10, 'init_time': '2023-01-02 13:21:59.199722 KST', 'start_time': '2023-01-02 13:21:59.199722 KST', 'end_time': ''}}
+{'request': 'start', 'response': 'broadcast', 'type': 'room_start', 'data': {'state': 1, 'time_offset': 3, 'time_duration': 10, 'init_time': '2023-01-03 17:52:37.710706 KST', 'start_time': '2023-01-03 17:52:42.125950 KST', 'end_time': ''}}
 @@@@@ send hand 0
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 1, 'lose': 0, 'room_id': 6}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:44.141414 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:37.710706 KST', 'room_id': 8}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 0, 'draw': 1, 'lose': 0, 'room_id': 8}]}
 @@@@@@ send hand 1 -> lose
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-02 13:22:07.337083 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': -1, 'win': 0, 'draw': 1, 'lose': 1, 'room_id': 6}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-03 17:52:47.176208 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:44.141414 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:37.710706 KST', 'room_id': 8}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': -1, 'win': 0, 'draw': 1, 'lose': 1, 'room_id': 8}]}
 @@@@@@@ send hand 0 -> win
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 1, 'time': '2023-01-02 13:22:09.378423 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-02 13:22:07.337083 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 1, 'draw': 1, 'lose': 1, 'room_id': 6}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 1, 'time': '2023-01-03 17:52:49.217979 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-03 17:52:47.176208 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:44.141414 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': ' 관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:37.710706 KST', 'room_id': 8}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 1, 'draw': 1, 'lose': 1, 'room_id': 8}]}
 @@@@@@@@ end response
-{'request': 'end', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 1, 'time': '2023-01-02 13:22:09.378423 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-02 13:22:07.337083 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:22:04.275407 KST', 'room_id': 6}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 0, 'time': '2023-01-02 13:21:59.199722 KST', 'room_id': 6}]}
-{'request': 'end', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '관리자', 'is_admin': True, 'score': 0, 'win': 1, 'draw': 1, 'lose': 1, 'room_id': 6}]}
+{'request': 'end', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '관리자', 'hand': 0, 'score': 1, 'time': '2023-01-03 17:52:49.217979 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': '관리자', 'hand': 1, 'score': -1, 'time': '2023-01-03 17:52:47.176208 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': '관리 자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:44.141414 KST', 'room_id': 8}, {'affiliation': 'STAFF', 'name': ' 관리자', 'hand': 0, 'score': 0, 'time': '2023-01-03 17:52:37.710706 KST', 'room_id': 8}]}
+{'request': 'end', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': ' 관리자', 'is_admin': True, 'score': 0, 'win': 1, 'draw': 1, 'lose': 1, 'room_id': 8}]}
 @@@@@@@@@ send hand 0 -> not connected
 
 --------- Test 3: join and error and disconnect ---------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 7, 'person_id': 3}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 9, 'person_id': 3}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 9}]}
 @@ send plain text (not a JSON)
 {'request': '', 'response': 'error', 'type': 'message', 'message': 'Bad request'}
 @@@ disconnected (without sending quit)
 @@@@ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 7, 'person_id': 3}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 9, 'person_id': 3}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 9}]}
 @@@@@ send start (without required keyword arguments) -> disconnect
 {'state': 0, 'time_offset': -1, 'time_duration': -1, 'init_time': '', 'start_time': '', 'end_time': ''}
 @@@@@@ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 7, 'person_id': 3}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 9, 'person_id': 3}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 9}]}
 @@@@@@@ disconnected (without sending quit)
 
 ---------------- Test 4: forbidden start ----------------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'UPnL', 'name': '아무개', 'is_admin': False, 'room_id': 7, 'person_id': 4}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'UPnL', 'name': '아무개', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 7}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'UPnL', 'name': '아무개', 'is_admin': False, 'room_id': 9, 'person_id': 4}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'UPnL', 'name': ' 아무개', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 9}]}
 @@ send start 3 10
 {'request': 'start', 'response': 'error', 'type': 'message', 'message': 'Forbidden'}
 @@@ send quit

--- a/README.md
+++ b/README.md
@@ -537,8 +537,11 @@ disconnect broadcast: 요청 데이터에 필요한 정보가 모두 들어있�
 * `python ./backend_websocket_test.py`
 
 #### 현재 테스트한 항목
+##### Test 1
 * join을 통한 웹 소켓 연결: 성공
 * quit 요청을 통해 대기 방에서 나가기: 성공
+  
+##### Test 2
 * start 요청을 통해 대기 방에서 플레이 중인 방으로 전환하기: 성공
 * start 직후에 hand 요청을 날리고 오류 메시지 받기: 성공
 * start 후 5초 후에 손 입력을 받기 시작한다는 메시지 받기: 성공
@@ -546,10 +549,18 @@ disconnect broadcast: 요청 데이터에 필요한 정보가 모두 들어있�
 * 손 입력을 받기 시작한 후 5초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
 * 손 입력을 받기 시작한 후 7초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
 * 손 입력을 받기 시작한 후 10초 후(게임이 종료될 시간)에 end 응답 받기: 성공
+* 게임 종료 이후 손 입력을 요청하는 경우 이미 연결이 끊긴 상황이라 오류 발생: 확인
+  
+##### Test 3
+* 요청 양식(JSON)에 맞지 않는 요청을 날리고 오류 메시지 받기: 성공
+* 대기 방에서 quit 요청 없이 임의로 연결을 종료해도 이후에 같은 소속과 이름의 계정으로 새로운 방에 들어갈 수 있음: 확인
+* 대기 방에서 start 요청을 `time_offset`과 `time_duration` 없이 날리고 서버에 의해 연결 끊기기: 성공
+* 서버에 의해 연결이 끊겨도 이후에 같은 소속과 이름의 계정으로 새로운 방에 들어갈 수 있음: 확인
 
 #### 테스트하지 않은 항목
-* 각종 오류 메시지
-* 접속이 중간에 끊기는 경우
+* 여러 명이 동시에 한 방에 들어가고 나가고 연결이 끊기는 상황
+* 여러 방에서 동시에 게임이 돌아가는 상황
+* 플레이 중인 방에서 연결이 끊겼을 때 다시 입장하려는 상황 -> 아직 구현이 안 되어 있지만 기존의 방이 아직 플레이 중인 상태라면 그 방으로 재입장하도록 구현할 예정
 
 #### 테스트 로그
 * `python ./backend_websocket_test.py`
@@ -557,32 +568,51 @@ disconnect broadcast: 요청 데이터에 필요한 정보가 모두 들어있�
 ```
 ----------------- Test 1: join and quit -----------------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'game', 'data': {'person_id': 5, 'room_id': 16}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 16}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'room_id': 10, 'person_id': 3}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 10}]}
 @@ send quit
 {'request': 'quit', 'response': 'success', 'type': 'message', 'message': 'Successfully signed out'}
 
 ------------ Test 2: join and start and hand ------------
 @ send join
-{'request': 'join', 'response': 'success', 'type': 'game', 'data': {'person_id': 19, 'room_id': 16}}
-{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 16}]}
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'room_id': 10, 'person_id': 13}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 10}]}
 @@ send start 5 10
-{'request': 'start', 'response': 'broadcast', 'type': 'room', 'data': {'state': 1, 'time_offset': 5, 'time_duration': 10, 'init_time': '2022-12-29 22:47:33.435833 KST', 'start_time': '', 'end_time': ''}}
-{'request': 'start', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
-{'request': 'start', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 16}]}
+{'request': 'start', 'response': 'broadcast', 'type': 'room', 'data': {'state': 1, 'time_offset': 5, 'time_duration': 10, 'init_time': '2022-12-30 13:28:35.399589 KST', 'start_time': '', 'end_time': ''}}
+{'request': 'start', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
+{'request': 'start', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 10}]}
 @@@ send hand 0 -> error response
 {'request': 'hand', 'response': 'error', 'type': 'message', 'message': 'Game not started yet'}
 @@@@ start response
 {'request': 'start', 'response': 'broadcast', 'type': 'message', 'message': 'Game start'}
 @@@@@ send hand 0
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': -1, 'time': '2022-12-29 22:47:40.517469 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -1, 'win': 0, 'draw': 0, 'lose': 1, 'room_id': 16}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': -1, 'time': '2022-12-30 13:28:42.499772 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -1, 'win': 0, 'draw': 0, 'lose': 1, 'room_id': 10}]}
 @@@@@@ send hand 1 -> lose
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 1, 'score': -1, 'time': '2022-12-29 22:47:43.551922 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': -1, 'time': '2022-12-29 22:47:40.517469 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -2, 'win': 0, 'draw': 0, 'lose': 2, 'room_id': 16}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 1, 'score': -1, 'time': '2022-12-30 13:28:45.537418 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': -1, 'time': '2022-12-30 13:28:42.499772 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -2, 'win': 0, 'draw': 0, 'lose': 2, 'room_id': 10}]}
 @@@@@@@ send hand 0 -> win
-{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': 1, 'time': '2022-12-29 22:47:45.585604 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 1, 'score': -1, 'time': '2022-12-29 22:47:43.551922 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': -1, 'time': '2022-12-29 22:47:40.517469 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
-{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 16}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': 1, 'time': '2022-12-30 13:28:47.581427 KST', 'room_id': 10}, {'affiliation': 'STAFF', 
+'name': '2022-12-30 13:28:35.363117', 'hand': 1, 'score': -1, 'time': '2022-12-30 13:28:45.537418 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 0, 'score': -1, 'time': '2022-12-30 13:28:42.499772 KST', 'room_id': 10}, {'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'hand': 2, 'score': 0, 'time': '2022-12-30 13:28:35.399589 KST', 'room_id': 10}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 10}]}
 @@@@@@@@ end response
-{'request': 'end', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 16}]}
+{'request': 'end', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-30 13:28:35.363117', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 10}]}
+@@@@@@@@@ send hand 0 -> not connected
+
+--------- Test 3: join and error and disconnect ---------
+@ send join
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 11, 'person_id': 2}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 11}]}
+@@ send plain text (not a JSON)
+{'request': '', 'response': 'error', 'type': 'message', 'message': 'Bad request'}
+@@@ disconnected (without sending quit)
+@@@@ send join
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 11, 'person_id': 2}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 11}]}
+@@@@@ send start (without required keyword arguments) -> disconnect
+{'state': 0, 'time_offset': -1, 'time_duration': -1, 'init_time': '', 'start_time': '', 'end_time': ''}
+@@@@@@ send join
+{'request': 'join', 'response': 'success', 'type': 'profile', 'data': {'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'room_id': 11, 'person_id': 2}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test_villain', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 11}]}
+@@@@@@@ disconnected (without sending quit)
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Rock-Scissor-Paper Brawl
 * 네트워크 가위바위보 난투
-* FastAPI로 구현
+* 백엔드는 FastAPI로 구현
+* 프론트엔드는 React로 구현
+
+## Frontend
+### How to run
+
+#### Install
+* React 사용
+* `npm install -g react-scripts`
+* `npm install react react-dom`
+
+#### Run
+* `npm start`
+  * 브라우저에서 `http://127.0.0.1:3000` 접속
+* *유선 LAN을 사용하는 네트워크 환경에서는 다음 오류를 띄우며 실행이 되지 않을 수 있다.*
+  * `Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.`
+  * ` - options.allowedHosts[0] should be a non-empty string.`
+  * 이때는 Wi-Fi 또는 핫스팟을 사용하는 네트워크 환경에서 실행하면 잘 작동한다.
 
 ## Backend
 ### How to run
@@ -35,7 +52,7 @@ let ws = new WebSocket("ws://localhost:8000/join?affiliation=" + "소속" + "&na
 ```
 
 * 소속(`affiliation`)과 이름(`name`)을 가진 사람을 마지막 대기 방에 입장시킴 (회원가입 겸 로그인)
-* 특별히 `affiliation=Staff`이고 `name=관리자`인 사람은 admin으로 취급됨
+* 특별히 `affiliation=STAFF`이고 `name=관리자`인 사람은 admin으로 취급됨
 
 join error: 입장하려는 대기 방에 같은 사람이 이미 입장해 있는 경우 다음 메시지 응답
 ```
@@ -348,7 +365,7 @@ hand error: 방이 플레이 중인 방이지만 손 입력 가능 시간이 초
 
 #### POST `/room` (`affiliation`(string), `name`(string))
 * 소속(`affiliation`)과 이름(`name`)을 가진 사람을 마지막 대기 방에 입장시킴 (회원가입 겸 로그인)
-* 특별히 `affiliation=Staff`이고 `name=관리자`인 사람은 admin으로 표시됨
+* 특별히 `affiliation=STAFF`이고 `name=관리자`인 사람은 admin으로 표시됨
 * 같은 사람이 이미 다른 대기 방 또는 플레이 방에 들어가 있는 경우 새로 입장할 수 없음
 * `person_id`(사람 번호), `room_id`(입장한 방 번호) 등이 포함된 오브젝트(`{}`)를 반환
 * **계정 접속 창에서 입장 버튼을 누를 때 호출할 것!**

--- a/README.md
+++ b/README.md
@@ -468,5 +468,48 @@ hand error: 방이 플레이 중인 방이지만 손 입력 가능 시간이 초
 * quit 요청을 통해 대기 방에서 나가기: 성공
 * start 요청을 통해 대기 방에서 플레이 중인 방으로 전환하기: 성공
 * start 직후에 hand 요청을 날리고 오류 메시지 받기: 성공
-* start 후 6초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
-* start 후 게임이 종료될 시간 이후에 end 응답 받기: **실패**
+* start 후 5초 후에 손 입력을 받기 시작한다는 메시지 받기: 성공
+* 손 입력을 받기 시작한 후 2초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
+* 손 입력을 받기 시작한 후 5초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
+* 손 입력을 받기 시작한 후 7초 후에 hand 요청을 날리고 반영된 결과 받기: 성공
+* 손 입력을 받기 시작한 후 10초 후(게임이 종료될 시간)에 end 응답 받기: 성공
+
+#### 테스트하지 않은 항목
+* 각종 오류 메시지
+* 접속이 중간에 끊기는 경우
+
+#### 테스트 로그
+* `python ./backend_websocket_test.py`
+
+```
+----------------- Test 1: join and quit -----------------
+@ send join
+{'request': 'join', 'response': 'success', 'type': 'game', 'data': {'person_id': 5, 'room_id': 16}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': 'test', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 16}]}
+@@ send quit
+{'request': 'quit', 'response': 'success', 'type': 'message', 'message': 'Successfully signed out'}
+
+------------ Test 2: join and start and hand ------------
+@ send join
+{'request': 'join', 'response': 'success', 'type': 'game', 'data': {'person_id': 19, 'room_id': 16}}
+{'request': 'join', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 16}]}
+@@ send start 5 10
+{'request': 'start', 'response': 'broadcast', 'type': 'room', 'data': {'state': 1, 'time_offset': 5, 'time_duration': 10, 'init_time': '2022-12-29 22:47:33.435833 KST', 'start_time': '', 'end_time': ''}}
+{'request': 'start', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
+{'request': 'start', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': 0, 'win': 0, 'draw': 0, 'lose': 0, 'room_id': 16}]}
+@@@ send hand 0 -> error response
+{'request': 'hand', 'response': 'error', 'type': 'message', 'message': 'Game not started yet'}
+@@@@ start response
+{'request': 'start', 'response': 'broadcast', 'type': 'message', 'message': 'Game start'}
+@@@@@ send hand 0
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': -1, 'time': '2022-12-29 22:47:40.517469 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -1, 'win': 0, 'draw': 0, 'lose': 1, 'room_id': 16}]}
+@@@@@@ send hand 1 -> lose
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 1, 'score': -1, 'time': '2022-12-29 22:47:43.551922 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': -1, 'time': '2022-12-29 22:47:40.517469 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -2, 'win': 0, 'draw': 0, 'lose': 2, 'room_id': 16}]}
+@@@@@@@ send hand 0 -> win
+{'request': 'hand', 'response': 'broadcast', 'type': 'hand_list', 'data': [{'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': 1, 'time': '2022-12-29 22:47:45.585604 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 1, 'score': -1, 'time': '2022-12-29 22:47:43.551922 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 0, 'score': -1, 'time': '2022-12-29 22:47:40.517469 KST', 'room_id': 16}, {'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'hand': 2, 'score': 0, 'time': '2022-12-29 22:47:33.435833 KST', 'room_id': 16}]}
+{'request': 'hand', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 16}]}
+@@@@@@@@ end response
+{'request': 'end', 'response': 'broadcast', 'type': 'game_list', 'data': [{'rank': 1, 'affiliation': 'STAFF', 'name': '2022-12-29 22:47:33.391697', 'is_admin': False, 'score': -1, 'win': 1, 'draw': 0, 'lose': 2, 'room_id': 16}]}
+```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 #### Install
 * React 사용
-* `npm install -g react-scripts`
-* `npm install react react-dom`
+* `cd client`
+* `npm install`
+  * 잘 안 되면 `npm install --force`
 
 #### Run
 * `npm start`
@@ -34,7 +35,7 @@
 * `pip install sqlalchemy`
 * `pip install websockets`
 * `pip install pytz`
-* `pip install httpx` (테스트 용도)
+* `pip install httpx` (테스트 코드에서만 사용)
 
 #### Run
 * `cd {root_of_this_repository}`

--- a/asyncio_test.py
+++ b/asyncio_test.py
@@ -1,0 +1,76 @@
+import asyncio
+import datetime
+
+async def say(t, msg):
+    await asyncio.sleep(t)
+    print(msg, datetime.datetime.now())
+
+async def main1():
+    print(datetime.datetime.now())
+    await asyncio.sleep(3)
+    print('3sleep')
+    task1 = asyncio.create_task(say(1, '4hello'))
+    task2 = asyncio.create_task(say(2, '5world'))
+    await task1
+    await task2
+    for i in range(3):
+        print(5)
+    await say(1, '6eholl')
+
+async def main2():
+    print(datetime.datetime.now())
+    task1 = asyncio.create_task(say(1, '1hello'))
+    task2 = asyncio.create_task(say(2, '2world'))
+    await asyncio.sleep(3)
+    print('3sleep')
+    await task1
+    await task2
+    for i in range(3):
+        print(3)
+    await say(1, '4eholl')
+
+async def main3():
+    # Require Python version >= 3.11
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(say(1, '1hello'))
+        tg.create_task(say(2, '2hello'))
+        tg.create_task(asyncio.sleep(3))
+    print('3sleep')
+    await say(1, '4eholl')
+
+async def main4():
+    print(datetime.datetime.now())
+    task1 = asyncio.create_task(say(1, '1hello'))
+    task2 = asyncio.create_task(say(2, '2world'))
+    task3 = asyncio.create_task(asyncio.sleep(3))
+    await task1
+    await task2
+    await task3
+    print('3sleep')
+    task1 = asyncio.create_task(say(1, '4hello'))
+    task2 = asyncio.create_task(say(2, '5world'))
+    await task1
+    await task2
+
+async def main5():
+    print(datetime.datetime.now())
+    task1 = asyncio.create_task(say(1, '1I'))
+    task2 = asyncio.create_task(say(2, '2love'))
+    task3 = asyncio.create_task(asyncio.sleep(3))
+    await task1
+    await task2
+    await task3
+    print('3sleep')
+    task1 = asyncio.create_task(say(1, '4you'))
+    task2 = asyncio.create_task(say(2, '5!!!!'))
+    await task1
+    await task2
+
+async def main5_helper():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.create_task(main5())
+    loop.run_forever()
+
+asyncio.run(main4())
+print("end")

--- a/backend_websocket_test.py
+++ b/backend_websocket_test.py
@@ -8,21 +8,24 @@ def test_websocket_join_and_quit(app):
     # 입장 요청
     print("@ send join")
     with client.websocket_connect("/join?affiliation=STAFF&name=test") as websocket:
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "success"
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "broadcast"
+        try:
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "success"
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "broadcast"
 
-        # 퇴장 요청
-        print("@@ send quit")
-        websocket.send_json({
-            'request': 'quit'
-        })
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "quit" and data["response"] == "success"
+            # 퇴장 요청
+            print("@@ send quit")
+            websocket.send_json({
+                'request': 'quit'
+            })
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "quit" and data["response"] == "success"
+        except AssertionError:
+            pass
 
 
 def test_websocket_join_and_start_and_hand(app):
@@ -30,106 +33,110 @@ def test_websocket_join_and_start_and_hand(app):
     print("------------ Test 2: join and start and hand ------------")
     # 입장 요청
     print("@ send join")
-    with client.websocket_connect("/join?affiliation=STAFF&name=" + str(datetime.datetime.now())) as websocket:
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "success"
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "broadcast"
-        
-        # 게임 시작 요청
-        print("@@ send start 5 10")
-        websocket.send_json({
-            'request': 'start',
-            'time_offset': 5,
-            'time_duration': 10
-        })
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'room'
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'hand_list'
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'game_list'
-
-        # 게임 시작 후 손 입력을 받기 전에 손 입력 요청 -> 오류 응답
-        print("@@@ send hand 0 -> error response")
-        websocket.send_json({
-            'request': 'hand',
-            'hand': 0
-        })
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "hand" and data["response"] == "error"
-
-        # 손 입력을 받기 시작한다는 응답
-        data = websocket.receive_json(mode='text')
-        print("@@@@ start response")
-        print(data)
-        assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'message'
-
-        time.sleep(2)
-
-        # 손 입력을 받기 시작한 후에 손 입력 요청
-        print("@@@@@ send hand 0")
-        websocket.send_json({
-            'request': 'hand',
-            'hand': 0
-        })
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'hand_list'
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'game_list'
-
-        time.sleep(3)
-
-        # 손 입력을 받기 시작한 후에 손 입력 요청 (지는 손)
-        print("@@@@@@ send hand 1 -> lose")
-        websocket.send_json({
-            'request': 'hand',
-            'hand': 1
-        })
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'hand_list'
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'game_list'
-
-        time.sleep(2)
-
-        # 손 입력을 받기 시작한 후에 손 입력 요청 (이기는 손)
-        print("@@@@@@@ send hand 0 -> win")
-        websocket.send_json({
-            'request': 'hand',
-            'hand': 0
-        })
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'hand_list'
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'game_list'
-
-        # 게임이 종료되었다는 응답 -> 자동 퇴장
-        data = websocket.receive_json(mode='text')
-        print("@@@@@@@@ end response")
-        print(data)
-        assert data["request"] == "end" and data["response"] == "broadcast" and data["type"] == 'game_list'
-
-        print("@@@@@@@@@ send hand 0 -> not connected")
+    with client.websocket_connect("/join?affiliation=STAFF&name=관리자") as websocket:
         try:
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "success"
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "broadcast"
+            
+            # 게임 시작 요청
+            print("@@ send start 5 10")
+            websocket.send_json({
+                'request': 'start',
+                'time_offset': 5,
+                'time_duration': 10
+            })
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'room'
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'hand_list'
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'game_list'
+
+            # 게임 시작 후 손 입력을 받기 전에 손 입력 요청 -> 오류 응답
+            print("@@@ send hand 0 -> error response")
             websocket.send_json({
                 'request': 'hand',
                 'hand': 0
             })
-        except Exception as e:
-            assert e.__class__ == RuntimeError and str(e) == 'Cannot call "send" once a close message has been sent.'
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "hand" and data["response"] == "error"
+
+            # 손 입력을 받기 시작한다는 응답
+            data = websocket.receive_json(mode='text')
+            print("@@@@ start response")
+            print(data)
+            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'room_start'
+
+            time.sleep(2)
+
+            # 손 입력을 받기 시작한 후에 손 입력 요청
+            print("@@@@@ send hand 0")
+            websocket.send_json({
+                'request': 'hand',
+                'hand': 0
+            })
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'hand_list'
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'game_list'
+
+            time.sleep(3)
+
+            # 손 입력을 받기 시작한 후에 손 입력 요청 (지는 손)
+            print("@@@@@@ send hand 1 -> lose")
+            websocket.send_json({
+                'request': 'hand',
+                'hand': 1
+            })
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'hand_list'
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'game_list'
+
+            time.sleep(2)
+
+            # 손 입력을 받기 시작한 후에 손 입력 요청 (이기는 손)
+            print("@@@@@@@ send hand 0 -> win")
+            websocket.send_json({
+                'request': 'hand',
+                'hand': 0
+            })
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'hand_list'
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "hand" and data["response"] == "broadcast" and data["type"] == 'game_list'
+
+            # 게임이 종료되었다는 응답 -> 자동 퇴장
+            data = websocket.receive_json(mode='text')
+            print("@@@@@@@@ end response")
+            print(data)
+            assert data["request"] == "end" and data["response"] == "broadcast" and data["type"] == 'game_list'
+
+            print("@@@@@@@@@ send hand 0 -> not connected")
+            try:
+                websocket.send_json({
+                    'request': 'hand',
+                    'hand': 0
+                })
+            except Exception as e:
+                assert e.__class__ == RuntimeError and str(e) == 'Cannot call "send" once a close message has been sent.'
+        
+        except AssertionError:
+            pass
 
 def test_websocket_join_and_error_and_disconnect(app):
     client = TestClient(app)
@@ -137,51 +144,100 @@ def test_websocket_join_and_error_and_disconnect(app):
     # 입장 요청
     print("@ send join")
     with client.websocket_connect("/join?affiliation=STAFF&name=test_villain") as websocket:
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "success"
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "broadcast"
+        try:
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "success"
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "broadcast"
 
-        print("@@ send plain text (not a JSON)")
-        websocket.send_text("Hello world!")
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "" and data["response"] == "error"
+            print("@@ send plain text (not a JSON)")
+            websocket.send_text("Hello world!")
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "" and data["response"] == "error"
+            
+            print("@@@ disconnected (without sending quit)")
         
-        print("@@@ disconnected (without sending quit)")
+        except AssertionError:
+            pass
 
     
     print("@@@@ send join")
     with client.websocket_connect("/join?affiliation=STAFF&name=test_villain") as websocket:
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "success"
-        room_id = data["data"]["room_id"]
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "broadcast"
+        try:
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "success"
+            room_id = data["data"]["room_id"]
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "broadcast"
 
-        print("@@@@@ send start (without required keyword arguments) -> disconnect")
-        websocket.send_json({
-            'request': 'start'
-        })
-        data = client.get("/room/" + str(room_id))
-        print(data.json())
-        assert data.json()["state"] == 0
+            print("@@@@@ send start (without required keyword arguments) -> disconnect")
+            websocket.send_json({
+                'request': 'start'
+            })
+            data = client.get("/room/" + str(room_id))
+            print(data.json())
+            assert data.json()["state"] == 0
+        
+        except AssertionError:
+            pass
 
     print("@@@@@@ send join")
     with client.websocket_connect("/join?affiliation=STAFF&name=test_villain") as websocket:
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "success"
-        room_id = data["data"]["room_id"]
-        data = websocket.receive_json(mode='text')
-        print(data)
-        assert data["request"] == "join" and data["response"] == "broadcast"
-        
-        print("@@@@@@@ disconnected (without sending quit)")
+        try:
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "success"
+            room_id = data["data"]["room_id"]
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "broadcast"
+            
+            print("@@@@@@@ disconnected (without sending quit)")
+            
+        except AssertionError:
+            pass
+
+def test_websocket_forbidden_start(app):
+    client = TestClient(app)
+    print("---------------- Test 4: forbidden start ----------------")
+    # 입장 요청
+    print("@ send join")
+    with client.websocket_connect("/join?affiliation=UPnL&name=아무개") as websocket:
+        try:
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "success"
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "join" and data["response"] == "broadcast"
+            
+            # 게임 시작 요청
+            print("@@ send start 5 10")
+            websocket.send_json({
+                'request': 'start',
+                'time_offset': 5,
+                'time_duration': 10
+            })
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "start" and data["response"] == "error"
+
+            # 퇴장 요청
+            print("@@@ send quit")
+            websocket.send_json({
+                'request': 'quit'
+            })
+            data = websocket.receive_json(mode='text')
+            print(data)
+            assert data["request"] == "quit" and data["response"] == "success"
+            
+        except AssertionError:
+            pass
 
 
 # 프로젝트 루트 폴더(sql_app 폴더의 상위 폴더)에서 실행할 것!
@@ -199,3 +255,6 @@ if __name__ == '__main__':
     test_websocket_join_and_start_and_hand(app)
     print()
     test_websocket_join_and_error_and_disconnect(app)
+    print()
+    test_websocket_forbidden_start(app)
+    print()

--- a/backend_websocket_test.py
+++ b/backend_websocket_test.py
@@ -43,10 +43,10 @@ def test_websocket_join_and_start_and_hand(app):
             assert data["request"] == "join" and data["response"] == "broadcast"
             
             # 게임 시작 요청
-            print("@@ send start 5 10")
+            print("@@ send start 3 10")
             websocket.send_json({
                 'request': 'start',
-                'time_offset': 5,
+                'time_offset': 3,
                 'time_duration': 10
             })
             data = websocket.receive_json(mode='text')
@@ -123,6 +123,9 @@ def test_websocket_join_and_start_and_hand(app):
             # 게임이 종료되었다는 응답 -> 자동 퇴장
             data = websocket.receive_json(mode='text')
             print("@@@@@@@@ end response")
+            print(data)
+            assert data["request"] == "end" and data["response"] == "broadcast" and data["type"] == 'hand_list'
+            data = websocket.receive_json(mode='text')
             print(data)
             assert data["request"] == "end" and data["response"] == "broadcast" and data["type"] == 'game_list'
 
@@ -217,10 +220,10 @@ def test_websocket_forbidden_start(app):
             assert data["request"] == "join" and data["response"] == "broadcast"
             
             # 게임 시작 요청
-            print("@@ send start 5 10")
+            print("@@ send start 3 10")
             websocket.send_json({
                 'request': 'start',
-                'time_offset': 5,
+                'time_offset': 3,
                 'time_duration': 10
             })
             data = websocket.receive_json(mode='text')

--- a/backend_websocket_test.py
+++ b/backend_websocket_test.py
@@ -51,13 +51,7 @@ def test_websocket_join_and_start_and_hand(app):
             })
             data = websocket.receive_json(mode='text')
             print(data)
-            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'room'
-            data = websocket.receive_json(mode='text')
-            print(data)
-            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'hand_list'
-            data = websocket.receive_json(mode='text')
-            print(data)
-            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'game_list'
+            assert data["request"] == "start" and data["response"] == "broadcast" and data["type"] == 'init_data'
 
             # 게임 시작 후 손 입력을 받기 전에 손 입력 요청 -> 오류 응답
             print("@@@ send hand 0 -> error response")

--- a/backend_websocket_test.py
+++ b/backend_websocket_test.py
@@ -150,7 +150,38 @@ def test_websocket_join_and_error_and_disconnect(app):
         print(data)
         assert data["request"] == "" and data["response"] == "error"
         
-        print("@@@ disconnect (without sending quit)")
+        print("@@@ disconnected (without sending quit)")
+
+    
+    print("@@@@ send join")
+    with client.websocket_connect("/join?affiliation=STAFF&name=test_villain") as websocket:
+        data = websocket.receive_json(mode='text')
+        print(data)
+        assert data["request"] == "join" and data["response"] == "success"
+        room_id = data["data"]["room_id"]
+        data = websocket.receive_json(mode='text')
+        print(data)
+        assert data["request"] == "join" and data["response"] == "broadcast"
+
+        print("@@@@@ send start (without required keyword arguments) -> disconnect")
+        websocket.send_json({
+            'request': 'start'
+        })
+        data = client.get("/room/" + str(room_id))
+        print(data.json())
+        assert data.json()["state"] == 0
+
+    print("@@@@@@ send join")
+    with client.websocket_connect("/join?affiliation=STAFF&name=test_villain") as websocket:
+        data = websocket.receive_json(mode='text')
+        print(data)
+        assert data["request"] == "join" and data["response"] == "success"
+        room_id = data["data"]["room_id"]
+        data = websocket.receive_json(mode='text')
+        print(data)
+        assert data["request"] == "join" and data["response"] == "broadcast"
+        
+        print("@@@@@@@ disconnected (without sending quit)")
 
 
 # 프로젝트 루트 폴더(sql_app 폴더의 상위 폴더)에서 실행할 것!
@@ -158,7 +189,6 @@ if __name__ == '__main__':
     if __package__ is None:
         import sys
         from os import path
-        print(path.dirname(path.abspath(__file__)))
         sys.path.append(path.dirname(path.abspath(__file__)))
 
         from sql_app.main import app

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.2.1",
         "react": "^18.2.0",
+        "react-csv": "^2.2.2",
         "react-dom": "^18.2.0",
         "react-responsive-combo-box": "^1.3.0",
         "react-router-dom": "^6.4.5",
@@ -14190,6 +14191,11 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/react-csv": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-csv/-/react-csv-2.2.2.tgz",
+      "integrity": "sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw=="
     },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.2.1",
     "react": "^18.2.0",
+    "react-csv": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-responsive-combo-box": "^1.3.0",
     "react-router-dom": "^6.4.5",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,9 +6,12 @@ import {
   GameRoomPage,
 } from "./pages";
 import { Route, Routes } from "react-router-dom";
-
+import { BASE_WEBSOCKET_URL } from "./Config";
 import styled from "styled-components";
 import "./App.css";
+import { useState, useRef, useEffect, createContext } from "react";
+import { WebsocketContext } from "./utils/WebSocketProvider";
+import { WebsocketProvider } from "./utils/WebSocketProvider";
 const Background = styled.div`
   width: 100%;
   height: 100vh;
@@ -17,12 +20,14 @@ const Background = styled.div`
 
 function App() {
   return (
-    <Background>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/room/:room_id/*" element={<GameRoomPage />} />
-      </Routes>
-    </Background>
+    <WebsocketProvider>
+      <Background>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/room/:room_id/*" element={<GameRoomPage />} />
+        </Routes>
+      </Background>
+    </WebsocketProvider>
   );
 }
 

--- a/client/src/components/common/SelectBox.js
+++ b/client/src/components/common/SelectBox.js
@@ -8,7 +8,7 @@ export default function SelectBox({ selectedOption, setSelectedOption }) {
     "KING",
     "UPnL",
     "SNUGDC",
-    "CAT&Dog",
+    "CAT&DOG",
     "G-POS",
     "HAJE",
     "PoolC",

--- a/client/src/components/gameroom/FirstPlace.js
+++ b/client/src/components/gameroom/FirstPlace.js
@@ -4,21 +4,21 @@ import { Medium } from "../../styles/font";
 import styled from "styled-components";
 import BgBox from "../common/BgBox";
 import SvgIcon from "../common/SvgIcon";
+
 //1등 점수 정보
-export default function FirstPlace({}) {
-  const belong = "KING";
-  const name = "김서연";
-  const score = 7;
+export default function FirstPlace({ place }) {
+  const { affiliation, score, name } = place;
+
   return (
     <BgBox width={"350px"} height={"100px"}>
       <Row>
         <SvgIcon src={TrophySrc} size={"80px"} />
         <Col>
-          <Medium size="35px">{belong}</Medium>
+          <Medium size="35px">{affiliation}</Medium>
 
           <Medium size="25px">{name}</Medium>
         </Col>
-        <Medium size="40px">{score > 0 ? "+" + score : "-" + score}</Medium>
+        <Medium size="40px">{score >= 0 ? "+" + score : score}</Medium>
       </Row>
     </BgBox>
   );

--- a/client/src/components/gameroom/MyPlace.js
+++ b/client/src/components/gameroom/MyPlace.js
@@ -3,21 +3,21 @@ import TrophySrc from "../../assets/images/1st_trophy.svg";
 import { Medium } from "../../styles/font";
 import styled from "styled-components";
 import BgBox from "../common/BgBox";
-//1등 점수 정보
-export default function MyPlace({}) {
-  const belong = "소속";
-  const name = "내이름";
-  const score = 7;
+
+//내 점수 정보
+export default function MyPlace({ place }) {
+  const { affiliation, score, name, rank } = place;
+
   return (
     <BgBox width={"350px"} height={"130px"}>
       <Row>
-        <Rank rank={5} />
+        <Rank rank={rank} />
         <Col>
-          <Medium size="45px">{belong}</Medium>
+          <Medium size="45px">{affiliation}</Medium>
 
           <Medium size="30px">{name}</Medium>
         </Col>
-        <Medium>{score > 0 ? "+" + score : "-" + score}</Medium>
+        <Medium>{score >= 0 ? "+" + score : score}</Medium>
       </Row>
     </BgBox>
   );
@@ -52,6 +52,7 @@ const Row = styled.div`
 
 const Col = styled.div`
   display: flex;
+  flex: 0.3;
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;

--- a/client/src/components/gameroom/NetworkLogs.js
+++ b/client/src/components/gameroom/NetworkLogs.js
@@ -1,15 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import TrophySrc from "../../assets/images/1st_trophy.svg";
 import { Medium } from "../../styles/font";
 import styled from "styled-components";
 import BgBox from "../common/BgBox";
 import { Rock, Paper, Scissor } from "./RPS.js";
 import SizedBox from "../common/SizedBox";
+import useInterval from "../../utils/useInterval";
+import { useParams } from "react-router-dom";
+import HTTP from "../../utils/HTTP";
+import { WebsocketContext } from "../../utils/WebSocketProvider";
+import { useContext, useEffect } from "react";
+
 //1등 점수 정보
-export default function NetworkLogs({ logs }) {
-  const belong = "소속";
-  const name = "내이름";
-  const score = 7;
+export default function NetworkLogs({ hand_list }) {
+  var rpsDic = { 0: "rock", 1: "scissor", 2: "paper" };
+  const [logs, setLogs] = useState(hand_list);
+  const [createSocketConnection, ready, res, send] =
+    useContext(WebsocketContext); //전역 소켓 불러오기
+
+  useEffect(() => {
+    console.log(res);
+    /*손목록 갱신하기*/
+    if (ready) {
+      switch (res.type) {
+        case "hand_list":
+          setLogs(res.data);
+      }
+    }
+  }, [ready, send, res]); // 메시지가 도착하면
   return (
     <div>
       <Medium size={"40px"} color={"white"}>
@@ -17,32 +35,56 @@ export default function NetworkLogs({ logs }) {
       </Medium>
       <SizedBox height={"10px"} />
       <BgBox width={"350px"} height={"300px"}>
-        <Col>
+        <ScrollView>
           {/*네트워크 로그*/}
-          <Log belong="King" name="김서연" rps="rock" score={100} />
-          <Log belong="King" name="김서연" rps="rock" score={100} />
-        </Col>
+          {logs &&
+            logs.map(({ affiliation, name, hand, score }, idx) => (
+              <Log
+                belong={affiliation}
+                key={idx}
+                name={name}
+                rps={rpsDic[hand]}
+                score={score}
+              />
+            ))}
+        </ScrollView>
       </BgBox>
     </div>
   );
 }
 
-function Log({ belong, name, rps }) {
-  var rps = <Rock size="50px" />;
+function Log({ belong, name, rps, score }) {
+  var rpsDic = {
+    rock: <Rock size="50px" />,
+    scissor: <Scissor size="50px" />,
+    paper: <Paper size="50px" />,
+  };
 
   return (
     <Row>
       <Medium size={"30px"}>{belong}</Medium>
       <Medium size={"30px"}>{name}</Medium>
-      {rps}
-
-      <Medium color="var(--mint)" size={"30px"}>
-        +1
-      </Medium>
+      {rpsDic[rps]}
+      {score >= 0 ? (
+        <Medium color="var(--mint)" size={"30px"}>
+          +{score}
+        </Medium>
+      ) : (
+        <Medium color="var(--red)" size={"30px"}>
+          {score}
+        </Medium>
+      )}
     </Row>
   );
 }
-
+const ScrollView = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
 const Row = styled.div`
   display: flex;
   flex-direction: row;

--- a/client/src/components/gameroom/RPSSelection.js
+++ b/client/src/components/gameroom/RPSSelection.js
@@ -3,24 +3,41 @@ import styled from "styled-components";
 import RockSrc from "../../assets/images/rock.png";
 import ScissorSrc from "../../assets/images/scissor.png";
 import PaperSrc from "../../assets/images/paper.png";
-
+import HTTP from "../../utils/HTTP";
+import { useParams } from "react-router-dom";
+import { useContext } from "react";
+import { WebsocketContext } from "../../utils/WebSocketProvider";
 export default function RPSSelection({ last }) {
   var rpsDic = { 0: RockSrc, 1: ScissorSrc, 2: PaperSrc };
 
+  const { room_id } = useParams();
+
+  const [lastRPS, setLastRPS] = useState(last);
+  const [createSocketConnection, ready, res, send] =
+    useContext(WebsocketContext); //전역 소켓 불러오기
+  const person_id = sessionStorage.getItem("person_id");
+
+  const _addHand = (hand) => {
+    let request = {
+      request: "hand",
+      hand: hand, // 0(Rock) 또는 1(Scissor) 또는 2(Paper)
+    };
+    send(JSON.stringify(request));
+  };
   return (
     <>
       <img src={rpsDic[last]} width="500px" />
       <Row>
         <ImgBox>
-          <img src={RockSrc} width="100px" />
+          <img src={RockSrc} width="100px" onClick={() => _addHand(0)} />
         </ImgBox>
 
         <ImgBox>
-          <img src={ScissorSrc} width="100px" />
+          <img src={ScissorSrc} width="100px" onClick={() => _addHand(1)} />
         </ImgBox>
         <ImgBox>
           {" "}
-          <img src={PaperSrc} width="100px" />
+          <img src={PaperSrc} width="100px" onClick={() => _addHand(2)} />
         </ImgBox>
       </Row>
     </>

--- a/client/src/components/gameroom/RPSSelection.js
+++ b/client/src/components/gameroom/RPSSelection.js
@@ -7,15 +7,13 @@ import HTTP from "../../utils/HTTP";
 import { useParams } from "react-router-dom";
 import { useContext } from "react";
 import { WebsocketContext } from "../../utils/WebSocketProvider";
-export default function RPSSelection({ last }) {
+export default function RPSSelection({ lastHand }) {
   var rpsDic = { 0: RockSrc, 1: ScissorSrc, 2: PaperSrc };
 
   const { room_id } = useParams();
 
-  const [lastRPS, setLastRPS] = useState(last);
   const [createSocketConnection, ready, res, send] =
     useContext(WebsocketContext); //전역 소켓 불러오기
-  const person_id = sessionStorage.getItem("person_id");
 
   const _addHand = (hand) => {
     let request = {
@@ -26,7 +24,7 @@ export default function RPSSelection({ last }) {
   };
   return (
     <>
-      <img src={rpsDic[last]} width="500px" />
+      <img src={rpsDic[lastHand]} width="500px" />
       <Row>
         <ImgBox>
           <img src={RockSrc} width="100px" onClick={() => _addHand(0)} />

--- a/client/src/components/gameroom/ResultBoard.js
+++ b/client/src/components/gameroom/ResultBoard.js
@@ -55,11 +55,11 @@ const ScrollView = styled.div`
 function Place({ rank, belong, name, score }) {
   var img = <Rank rank={rank} />;
 
-  if (rank == 1) {
+  if (rank === 1) {
     img = <SvgIcon src={GoldSrc} size="30px" />;
-  } else if (rank == 2) {
+  } else if (rank === 2) {
     img = <SvgIcon src={SilverSrc} size="30px" />;
-  } else if (rank == 3) {
+  } else if (rank === 3) {
     img = <SvgIcon src={BronzeSrc} size="30px" />;
   }
 

--- a/client/src/components/gameroom/ResultBoard.js
+++ b/client/src/components/gameroom/ResultBoard.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import ClockSrc from "../../assets/images/clock.png";
 import { Medium } from "../../styles/font";
 import SvgIcon from "../common/SvgIcon";
@@ -8,8 +8,36 @@ import GoldSrc from "../../assets/images/1st.svg";
 import SilverSrc from "../../assets/images/2nd.svg";
 import BronzeSrc from "../../assets/images/3rd.svg";
 import SizedBox from "../common/SizedBox";
+import { getUserName, getUserAffiliation } from "../../utils/User";
+export default function ResultBoard({ result }) {
+  console.log(result);
+  const [myPlace, setMyPlace] = useState({
+    name: "이름",
+    affiliation: "소속",
+    rank: 0,
+    score: 0,
+  });
+  const my_name = getUserName();
+  const my_affiliation = getUserAffiliation();
+  const _findMyPlace = () => {
+    for (var place of result) {
+      if (place.name == my_name && place.affiliation == my_affiliation) {
+        // 소속, 이름이 같으면
+        return place;
+      }
+    }
+    return {
+      name: "이름",
+      affiliation: "소속",
+      rank: 0,
+      score: 0,
+    };
+  };
 
-export default function ResultBoard() {
+  useEffect(() => {
+    setMyPlace(_findMyPlace());
+  }, []);
+
   return (
     <BgBox width="30%" height="90%" bgColor={"var(--light-purple)"}>
       <Col>
@@ -20,23 +48,25 @@ export default function ResultBoard() {
         <SizedBox height={10} />
         <BgBox width="90%" height="10%" bgColor={"white"}>
           <Center>
-            <Place rank={1} belong="King" name="김서연" score={100} />
+            <Place
+              rank={myPlace?.rank}
+              belong={myPlace?.affiliation}
+              name={myPlace?.name}
+              score={myPlace?.score}
+            />
           </Center>
         </BgBox>
 
         <ScrollView>
-          <Place rank={1} belong="King" name="김서연" score={100} />
-          <Place rank={2} belong="King" name="김서연" score={80} />
-          <Place rank={3} belong="King" name="김서연" score={70} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
-          <Place rank={4} belong="King" name="김서연" score={60} />
+          {result.map(({ affiliation, rank, name, score }, idx) => (
+            <Place
+              key={idx}
+              rank={rank}
+              belong={affiliation}
+              name={name}
+              score={score}
+            />
+          ))}
         </ScrollView>
 
         <SizedBox height={10} />
@@ -80,7 +110,7 @@ function Place({ rank, belong, name, score }) {
       </Sector>
       <Sector>
         <Medium color="var(--mint)" size={"30px"}>
-          + {score}
+          {score >= 0 ? "+" + score : score}
         </Medium>
       </Sector>
     </Row>

--- a/client/src/components/gameroom/TimeBar.js
+++ b/client/src/components/gameroom/TimeBar.js
@@ -14,7 +14,7 @@ export default function TimeBar() {
     () => {
       setSec(sec - 1);
       console.log(sec);
-      if (sec == 1) {
+      if (sec === 1) {
         setIsRunning(false);
       }
     },

--- a/client/src/components/gameroom/UserList.js
+++ b/client/src/components/gameroom/UserList.js
@@ -1,9 +1,10 @@
 import React from "react";
 import { NameTag, AdminTag, MyNameTag } from "./NameTags";
 import styled from "styled-components";
+import { getUserName } from "../../utils/User";
 
 export default function UserList({ users }) {
-  const my_name = sessionStorage.getItem("person_name");
+  const my_name = getUserName();
   return (
     <Container>
       {users.map(({ affiliation, name }, idx) => {

--- a/client/src/components/gameroom/UserList.js
+++ b/client/src/components/gameroom/UserList.js
@@ -7,9 +7,9 @@ export default function UserList({ users }) {
   return (
     <Container>
       {users.map(({ affiliation, name }, idx) => {
-        if (name == my_name) {
+        if (name === my_name) {
           return <MyNameTag key={idx}>{name}</MyNameTag>;
-        } else if (affiliation == "STAFF") {
+        } else if (affiliation === "STAFF") {
           return <AdminTag key={idx}>{name}</AdminTag>;
         } else {
           return <NameTag key={idx}>{name}</NameTag>;

--- a/client/src/pages/GameResultPage.js
+++ b/client/src/pages/GameResultPage.js
@@ -6,6 +6,7 @@ import HTTP from "../utils/HTTP";
 import { useParams } from "react-router-dom";
 import { useNavigate, useLocation } from "react-router-dom";
 import { getUserId } from "../utils/User";
+import { CSVLink, CSVDownload } from "react-csv";
 
 export default function GameResultPage() {
   const { room_id } = useParams();
@@ -19,8 +20,10 @@ export default function GameResultPage() {
   return (
     <Row>
       <Button text="나가기" onClick={_quitGame} />
-      <ResultBoard result={state} />
-      <Button text="결과저장" />
+      <ResultBoard result={state} />;
+      <CSVLink data={state}>
+        <Button text="결과저장" />
+      </CSVLink>
     </Row>
   );
 }

--- a/client/src/pages/GameResultPage.js
+++ b/client/src/pages/GameResultPage.js
@@ -2,12 +2,24 @@ import React from "react";
 import ResultBoard from "../components/gameroom/ResultBoard";
 import Button from "../components/common/Button";
 import styled from "styled-components";
+import HTTP from "../utils/HTTP";
+import { useParams } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
+import { getUserId } from "../utils/User";
 
 export default function GameResultPage() {
+  const { room_id } = useParams();
+  const { state } = useLocation(); // 손 목록 정보, 게임 전적 정보
+  const person_id = getUserId();
+  const navigate = useNavigate();
+
+  const _quitGame = () => {
+    navigate("/");
+  };
   return (
     <Row>
-      <Button text="나가기" />
-      <ResultBoard />
+      <Button text="나가기" onClick={_quitGame} />
+      <ResultBoard result={state} />
       <Button text="결과저장" />
     </Row>
   );

--- a/client/src/pages/InGamePage.js
+++ b/client/src/pages/InGamePage.js
@@ -8,15 +8,17 @@ import RPSSelection from "../components/gameroom/RPSSelection";
 import { useLocation } from "react-router-dom";
 import { WebsocketContext } from "../utils/WebSocketProvider";
 import { useContext, useEffect } from "react";
-
+import { useNavigate } from "react-router-dom";
 import { getUserName, getUserAffiliation } from "../utils/User";
+import { useParams } from "react-router-dom";
 
 export default function InGamePage() {
   const { state } = useLocation(); // 손 목록 정보, 게임 전적 정보
   console.log(state);
   const my_name = getUserName();
+  const navigate = useNavigate();
   const my_affiliation = getUserAffiliation();
-
+  const { room_id } = useParams();
   const [myPlace, setMyPlace] = useState({
     name: my_name,
     affiliation: my_affiliation,
@@ -24,15 +26,19 @@ export default function InGamePage() {
     score: 0,
   });
 
+  const [firstPlace, setFirstPlace] = useState(state.gameList[0]);
+
   const [createSocketConnection, ready, res, send] =
     useContext(WebsocketContext); //전역 소켓 불러오기
 
   useEffect(() => {
     /*전적목록 갱신하기*/
     if (ready) {
-      switch (res.type) {
-        case "game_list":
+      switch (res.requset) {
+        case "hand": // 게임 전적 정보
           setMyPlace(_findMyPlace(res.data));
+          setFirstPlace(res.data[0]);
+          break;
       }
     }
   }, [ready, send, res]); // 메시지가 도착하면
@@ -45,7 +51,7 @@ export default function InGamePage() {
       }
     }
 
-    return { name: "없음", affiliation: "찾을수d없음", rank: 0 };
+    return { name: "없음", affiliation: "찾을수없음", rank: 0 };
   };
   return (
     <Container>
@@ -55,7 +61,7 @@ export default function InGamePage() {
       </Left>
 
       <Right>
-        <FirstPlace place={state.gameList[0]} />
+        <FirstPlace place={firstPlace} />
         <MyPlace place={myPlace} />
         <NetworkLogs hand_list={state.handList} />
       </Right>

--- a/client/src/pages/InGamePage.js
+++ b/client/src/pages/InGamePage.js
@@ -15,6 +15,9 @@ import { useParams } from "react-router-dom";
 export default function InGamePage() {
   const { state } = useLocation(); // 손 목록 정보, 게임 전적 정보
 
+  const [lastHand, setLastHand] = useState(0);
+
+  console.log(lastHand);
   const my_name = getUserName();
   const navigate = useNavigate();
   const my_affiliation = getUserAffiliation();
@@ -38,6 +41,9 @@ export default function InGamePage() {
           if (res.type === "game_list") {
             setMyPlace(_findMyPlace(res.data));
             setFirstPlace(res.data[0]);
+          } else if (res.type === "hand_list") {
+            setLastHand(res.data[0].hand); // 가장 최근에 입력된 손 갱신
+            console.log(res.data[0].hand);
           }
           break;
         case "end": // 게임 종료 신호
@@ -63,7 +69,7 @@ export default function InGamePage() {
     <Container>
       <Left>
         <TimeBar />
-        <RPSSelection />
+        <RPSSelection lastHand={lastHand} />
       </Left>
 
       <Right>

--- a/client/src/pages/InGamePage.js
+++ b/client/src/pages/InGamePage.js
@@ -5,8 +5,15 @@ import MyPlace from "../components/gameroom/MyPlace";
 import NetworkLogs from "../components/gameroom/NetworkLogs";
 import TimeBar from "../components/gameroom/TimeBar";
 import RPSSelection from "../components/gameroom/RPSSelection";
+import { useLocation } from "react-router-dom";
+import { WebsocketContext } from "../utils/WebSocketProvider";
+import { useContext, useEffect } from "react";
 
 export default function InGamePage() {
+  const { state } = useLocation(); // 손 목록 정보, 게임 전적 정보
+
+  console.log(state);
+
   return (
     <Container>
       <Left>
@@ -17,7 +24,7 @@ export default function InGamePage() {
       <Right>
         <FirstPlace />
         <MyPlace />
-        <NetworkLogs />
+        <NetworkLogs hand_list={state.handList} />
       </Right>
     </Container>
   );

--- a/client/src/pages/InGamePage.js
+++ b/client/src/pages/InGamePage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import FirstPlace from "../components/gameroom/FirstPlace";
 import MyPlace from "../components/gameroom/MyPlace";
@@ -9,11 +9,44 @@ import { useLocation } from "react-router-dom";
 import { WebsocketContext } from "../utils/WebSocketProvider";
 import { useContext, useEffect } from "react";
 
+import { getUserName, getUserAffiliation } from "../utils/User";
+
 export default function InGamePage() {
   const { state } = useLocation(); // 손 목록 정보, 게임 전적 정보
-
   console.log(state);
+  const my_name = getUserName();
+  const my_affiliation = getUserAffiliation();
 
+  const [myPlace, setMyPlace] = useState({
+    name: my_name,
+    affiliation: my_affiliation,
+    rank: 0,
+    score: 0,
+  });
+
+  const [createSocketConnection, ready, res, send] =
+    useContext(WebsocketContext); //전역 소켓 불러오기
+
+  useEffect(() => {
+    /*전적목록 갱신하기*/
+    if (ready) {
+      switch (res.type) {
+        case "game_list":
+          setMyPlace(_findMyPlace(res.data));
+      }
+    }
+  }, [ready, send, res]); // 메시지가 도착하면
+
+  const _findMyPlace = (gameList) => {
+    for (var user of gameList) {
+      if (user.name == my_name && user.affiliation == my_affiliation) {
+        // 소속, 이름이 같으면
+        return user;
+      }
+    }
+
+    return { name: "없음", affiliation: "찾을수d없음", rank: 0 };
+  };
   return (
     <Container>
       <Left>
@@ -22,8 +55,8 @@ export default function InGamePage() {
       </Left>
 
       <Right>
-        <FirstPlace />
-        <MyPlace />
+        <FirstPlace place={state.gameList[0]} />
+        <MyPlace place={myPlace} />
         <NetworkLogs hand_list={state.handList} />
       </Right>
     </Container>

--- a/client/src/pages/InGamePage.js
+++ b/client/src/pages/InGamePage.js
@@ -14,7 +14,7 @@ import { useParams } from "react-router-dom";
 
 export default function InGamePage() {
   const { state } = useLocation(); // 손 목록 정보, 게임 전적 정보
-  console.log(state);
+
   const my_name = getUserName();
   const navigate = useNavigate();
   const my_affiliation = getUserAffiliation();
@@ -32,13 +32,19 @@ export default function InGamePage() {
     useContext(WebsocketContext); //전역 소켓 불러오기
 
   useEffect(() => {
-    /*전적목록 갱신하기*/
     if (ready) {
-      switch (res.requset) {
-        case "hand": // 게임 전적 정보
-          setMyPlace(_findMyPlace(res.data));
-          setFirstPlace(res.data[0]);
+      switch (res.request) {
+        case "hand": // 게임 전적 정보 갱신
+          if (res.type === "game_list") {
+            setMyPlace(_findMyPlace(res.data));
+            setFirstPlace(res.data[0]);
+          }
           break;
+        case "end": // 게임 종료 신호
+          navigate(`/room/${room_id}/result`, {
+            // 결과화면으로 최종 전적정보 전달
+            state: res.data,
+          });
       }
     }
   }, [ready, send, res]); // 메시지가 도착하면

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -55,7 +55,7 @@ function LoginBox() {
 
   useEffect(() => {
     if (ready) {
-      if (res?.response == "error") {
+      if (res?.response === "error") {
         alert(res.message);
         return;
       }

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -62,13 +62,14 @@ function LoginBox() {
 
       switch (res?.type) {
         case "profile":
-          // 사용자 정보(이름,소속,저장)를 로컬스토리지에 저장
+          // 사용자 정보(이름,소속,저장,관리자 여부)를 로컬스토리지에 저장
           const { data } = res;
           console.log(data);
           setUserName(data.name);
           setUserAffiliation(data.affiliation);
           setUserId(data.person_id);
           setRoomId(data.room_id); // 할당된 룸 번호 저장
+          localStorage.setItem("is_admin", data.is_admin); // 관리자 여부
 
           break;
 

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -14,6 +14,7 @@ import Button from "../components/common/Button";
 import { Medium } from "../styles/font";
 import { useNavigate } from "react-router-dom";
 import { useRef, createContext, useEffect } from "react";
+
 import { useContext } from "react";
 import HTTP from "../utils/HTTP";
 import {
@@ -54,12 +55,12 @@ function LoginBox() {
 
   useEffect(() => {
     if (ready) {
-      if (res.response == "error") {
+      if (res?.response == "error") {
         alert(res.message);
         return;
       }
-      //console.log(res);
-      switch (res.type) {
+
+      switch (res?.type) {
         case "profile":
           // 사용자 정보(이름,소속,저장)를 로컬스토리지에 저장
           const { data } = res;
@@ -72,12 +73,13 @@ function LoginBox() {
           break;
 
         case "game_list":
+          console.log(res.data);
           if (roomId) {
             navigate(`/room/${roomId}/waiting`, { state: res.data }); // 게임 대기화면 이동 + 해당 방 목록 인원 전달
           }
       }
     }
-  }, [ready, send]); // 소켓연결에 성공했다면
+  }, [ready, send, res]); // 소켓연결에 성공했다면
 
   const _joinGame = () => {
     if (selectedOption === "" || name === "") {

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -40,7 +40,7 @@ function LoginBox() {
   var navigate = useNavigate();
 
   const _joinGame = () => {
-    if (selectedOption == "" || name == "") {
+    if (selectedOption === "" || name === "") {
       alert("소속과 이름을 모두 채워주세요.");
       return;
     }

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -13,9 +13,18 @@ import SelectBox from "../components/common/SelectBox";
 import Button from "../components/common/Button";
 import { Medium } from "../styles/font";
 import { useNavigate } from "react-router-dom";
+import { useRef, createContext, useEffect } from "react";
+import { useContext } from "react";
 import HTTP from "../utils/HTTP";
+import {
+  setUserName,
+  getUserName,
+  setUserId,
+  setUserAffiliation,
+} from "../utils/User";
 
 import { BASE_WEBSOCKET_URL } from "../Config";
+import { WebsocketContext } from "../utils/WebSocketProvider";
 function RuleBox() {
   return (
     <BgBox width="250px" height="300px" color="white">
@@ -37,42 +46,45 @@ function RuleBox() {
 function LoginBox() {
   const [name, setName] = useState("");
   const [selectedOption, setSelectedOption] = useState(""); //소속
+  const [roomId, setRoomId] = useState();
   var navigate = useNavigate();
+
+  const [createWebSocketConnection, ready, res, send] =
+    useContext(WebsocketContext); //전역 소켓 사용
+
+  useEffect(() => {
+    if (ready) {
+      if (res.response == "error") {
+        alert(res.message);
+        return;
+      }
+      //console.log(res);
+      switch (res.type) {
+        case "profile":
+          // 사용자 정보(이름,소속,저장)를 로컬스토리지에 저장
+          const { data } = res;
+          console.log(data);
+          setUserName(data.name);
+          setUserAffiliation(data.affiliation);
+          setUserId(data.person_id);
+          setRoomId(data.room_id); // 할당된 룸 번호 저장
+
+          break;
+
+        case "game_list":
+          if (roomId) {
+            navigate(`/room/${roomId}/waiting`, { state: res.data }); // 게임 대기화면 이동 + 해당 방 목록 인원 전달
+          }
+      }
+    }
+  }, [ready, send]); // 소켓연결에 성공했다면
 
   const _joinGame = () => {
     if (selectedOption === "" || name === "") {
       alert("소속과 이름을 모두 채워주세요.");
       return;
     }
-
-    try {
-      // 웹소켓 연결
-
-      let ws = new WebSocket(
-        `${BASE_WEBSOCKET_URL}/join?affiliation=${selectedOption}&name=${name}`
-      );
-
-      ws.onopen = (event) => {
-        console.log("Socket open", event);
-
-        // ws.send("Successfully connected to socket"); // 여기에서 오류 발생
-        ws.send(JSON.stringify({request: 'quit'}))      // 이것은 퇴장 요청, 적절히 수정 바람
-      };
-      ws.onerror = (err) => {
-        console.log("err occured", err);
-      };
-      ws.onclose = (event) => {
-        console.log("onclose!", event);
-      };
-      ws.onmessage = function (event) {
-        const data = JSON.parse(event.data); // 전달된 json string을 object로 변환
-
-        console.log("message from the server", data); //응답 정보 출력
-      };
-    } catch (e) {
-      console.log(e);
-      console.log("failed to connect socket");
-    }
+    createWebSocketConnection(selectedOption, name); // Socket Connection 생성
   };
   return (
     <BgBox width="250px" height="300px" color="white">

--- a/client/src/pages/WatingGamePage.js
+++ b/client/src/pages/WatingGamePage.js
@@ -16,7 +16,7 @@ export default function WatingGamePage() {
   const [numberOfUser, setNumberOfUser] = useState(1);
   const [users, setUsers] = useState([]);
 
-  const isAuthorized = sessionStorage.getItem("affiliation") == "STAFF";
+  const isAuthorized = sessionStorage.getItem("affiliation") === "STAFF";
 
   const person_id = sessionStorage.getItem("person_id");
   var navigate = useNavigate();
@@ -31,7 +31,7 @@ export default function WatingGamePage() {
 
     HTTP.get(`/room/${room_id}/game`)
       .then((res) => {
-        if (res.status == 200) {
+        if (res.status === 200) {
           setNumberOfUser(res.data.length);
           setUsers(res.data);
           console.log(res.data);
@@ -48,7 +48,7 @@ export default function WatingGamePage() {
   const _quitGame = () => {
     HTTP.delete(`/room/${room_id}?person_id=${person_id}`)
       .then((res) => {
-        if (res.status == 200) {
+        if (res.status === 200) {
           sessionStorage.removeItem("person_id");
           sessionStorage.removeItem("person_name");
           navigate("/");
@@ -64,7 +64,7 @@ export default function WatingGamePage() {
   const _startGame = () => {
     HTTP.put(`/room/${room_id}/play`)
       .then((res) => {
-        if (res.status == 200) {
+        if (res.status === 200) {
           navigate(`/room/${room_id}/game`);
         } else {
           alert("게임 입장에 실패하였습니다. 새로고침 후 다시시도해주세요.");

--- a/client/src/pages/WatingGamePage.js
+++ b/client/src/pages/WatingGamePage.js
@@ -22,10 +22,11 @@ import { useContext } from "react";
 
 export default function WatingGamePage() {
   const { room_id } = useParams();
-  const { state } = useLocation();
+  const { state } = useLocation(); // 유저 목록 정보
 
   const [numberOfUser, setNumberOfUser] = useState(state.length);
   const [users, setUsers] = useState(state);
+  const [start, setStart] = useState(false); //방장이 게임시작했는지 여부
   const isAuthorized = getUserAffiliation() === "STAFF";
 
   const person_id = getUserId();
@@ -46,6 +47,13 @@ export default function WatingGamePage() {
           } else if (res.request === "disconnected") {
             setUsers(res.data);
           }
+          break;
+        case "room": //게임 시작 요청
+          setStart(true);
+
+          break;
+        case "hand_list": //해당 방의 손 목록 정보
+          navigate(`/room/${room_id}/game`, { state: res.data });
       }
     }
   }, [ready, send, res]); // 메시지가 도착하면
@@ -60,7 +68,17 @@ export default function WatingGamePage() {
     }
   };
 
-  const _startGame = () => {};
+  const _startGame = () => {
+    if (ready) {
+      let request = {
+        request: "start",
+        time_offset: 5, // seconds, 플레이 중인 방으로 전환 후 처음 손을 입력받기까지 기다리는 시간
+        time_duration: 60, // seconds, 처음 손을 입력받기 시작한 후 손을 입력받는 시간대의 길이
+      };
+      send(request);
+      navigate(`/room/${room_id}/game`);
+    }
+  };
   return (
     <Container>
       <Medium color="white" size={"60px"}>

--- a/client/src/utils/User.js
+++ b/client/src/utils/User.js
@@ -12,3 +12,9 @@ export const setUserAffiliation = (affiliation) =>
   localStorage.setItem(USER_AFFILIATION, affiliation);
 export const getUserAffiliation = (affiliation) =>
   localStorage.getItem(USER_AFFILIATION);
+
+export const flush = () => {
+  localStorage.removeItem(USER_ID);
+  localStorage.removeItem(USER_NAME);
+  localStorage.removeItem(USER_AFFILIATION);
+};

--- a/client/src/utils/User.js
+++ b/client/src/utils/User.js
@@ -1,0 +1,14 @@
+const USER_ID = "person_id";
+const USER_NAME = "person_name";
+const USER_AFFILIATION = "person_affiliation";
+
+export const setUserId = (id) => localStorage.setItem(USER_ID, id);
+export const getUserId = (id) => localStorage.getItem(USER_ID, id);
+
+export const setUserName = (name) => localStorage.setItem(USER_NAME, name);
+export const getUserName = (name) => localStorage.getItem(USER_NAME, name);
+
+export const setUserAffiliation = (affiliation) =>
+  localStorage.setItem(USER_AFFILIATION, affiliation);
+export const getUserAffiliation = (affiliation) =>
+  localStorage.getItem(USER_AFFILIATION);

--- a/client/src/utils/WebSocketProvider.js
+++ b/client/src/utils/WebSocketProvider.js
@@ -1,7 +1,12 @@
 import { useState, useRef, useEffect } from "react";
 import { createContext } from "react";
 import { BASE_WEBSOCKET_URL } from "../Config";
-export const WebsocketContext = createContext([false, null, () => {}]);
+export const WebsocketContext = createContext([
+  () => {},
+  false,
+  null,
+  () => {},
+]);
 
 //                                            ready, value, send
 
@@ -42,6 +47,7 @@ export const WebsocketProvider = ({ children }) => {
     createWebSocketConnection,
     isReady,
     res,
+
     ws.current?.send.bind(ws.current),
   ];
 

--- a/client/src/utils/WebSocketProvider.js
+++ b/client/src/utils/WebSocketProvider.js
@@ -1,0 +1,53 @@
+import { useState, useRef, useEffect } from "react";
+import { createContext } from "react";
+import { BASE_WEBSOCKET_URL } from "../Config";
+export const WebsocketContext = createContext([false, null, () => {}]);
+
+//                                            ready, value, send
+
+// Make sure to put WebsocketProvider higher up in
+// the component tree than any consumers.
+export const WebsocketProvider = ({ children }) => {
+  const [isReady, setIsReady] = useState(false);
+  const [res, setRes] = useState(null);
+
+  const ws = useRef(null);
+  // 웹소켓 연결
+
+  function createWebSocketConnection(affiliation, name) {
+    const socket = new WebSocket(
+      `${BASE_WEBSOCKET_URL}/join?affiliation=${affiliation}&name=${name}`
+    );
+
+    socket.onopen = (event) => {
+      console.log("Socket open", event);
+      setIsReady(true);
+    };
+
+    socket.onclose = (event) => {
+      console.log("onclose!", event);
+      setIsReady(false);
+    };
+    socket.onmessage = function (event) {
+      const data = JSON.parse(event.data); // 전달된 json string을 object로 변환
+      setRes(data);
+
+      console.log("onmessage", data.type, data);
+    };
+
+    ws.current = socket;
+  }
+
+  const ret = [
+    createWebSocketConnection,
+    isReady,
+    res,
+    ws.current?.send.bind(ws.current),
+  ];
+
+  return (
+    <WebsocketContext.Provider value={ret}>
+      {children}
+    </WebsocketContext.Provider>
+  );
+};

--- a/sql_app/crud.py
+++ b/sql_app/crud.py
@@ -35,7 +35,7 @@ def hash_password(password: str):
     return password + "PleaseHashIt" # TODO
 
 def check_admin(affiliation: str, name: str):
-    admin_list = [("Staff", "관리자")]
+    admin_list = [("STAFF", "관리자")]
     filtered = [item for item in admin_list if item[0] == affiliation and item[1] == name]
     return len(filtered) > 0
 

--- a/sql_app/crud.py
+++ b/sql_app/crud.py
@@ -294,7 +294,10 @@ def create_hand(db: Session, room_id: int, person_id: int, hand: schemas.HandEnu
 def get_game(db: Session, room_id: int, person_id: int):
     db_game = db.query(models.Game).filter(and_(models.Game.room_id == room_id, \
         models.Game.person_id == person_id)).first()
-    return schemas.Game.from_orm(db_game)
+    if db_game is None:
+        return None
+    else:
+        return schemas.Game.from_orm(db_game)
 
 def create_game(db: Session, room_id: int, person_id: int):
     db_game = models.Game(room_id=room_id, person_id=person_id, score=0, \

--- a/sql_app/crud.py
+++ b/sql_app/crud.py
@@ -16,7 +16,7 @@ import random
 # * 시간 제한 넣기 -> 내부에서 Play 시간에만 손 입력을 받도록 했지만, 시간이 종료된 후에 직접 update_room_to_end()을 호출해 주어야 한다.
 # * (해결) Add Hand에서 해당 방에 해당 사람이 없는 경우 오류 발생
 # * (해결) 해당 방에 입장한 사람 수를 얻는 메서드 추가
-# * (해결) 해당 방의 사람들의 순위를 반환하는 메서드 추가 -> 이건 attribute로 들고 있지 않도록 한다.
+# * (해결) 해당 방의 사람들의 순위를 반환하는 메서드 추가 -> 이건 key로 들고 있지 않도록 한다.
 # * (무시) 해당 방의 특정 사람의 순위를 반환하는 메서드 추가?
 
 # 로그인 상태의 사람은 Wait 또는 Play 방에 들어가 있는 사람을 말한다.
@@ -161,6 +161,7 @@ def update_room_to_enter(db: Session, room_id: int, person_id: int):
 
 def update_room_to_quit(db: Session, room_id: int, person_id: int):
     # 해당 방에서 사람 퇴장(로그아웃)
+    # 대기 방인 경우에만 퇴장 가능
     db_room = db.query(models.Room).filter(models.Room.id == room_id)
     if db_room.first() is None:
         return (None, 1)

--- a/sql_app/main.py
+++ b/sql_app/main.py
@@ -496,6 +496,7 @@ async def manage_time_for_room(room_id: int, time_offset: int, time_duration: in
     await task1
     await task2
     crud.update_room_to_end(db, room_id)  # 백엔드 자체에서 시간으로 입력 가능 여부를 판단하면 안 되고, 함수를 호출한 순간 무조건 Ending 페이즈로 변경해야 한다.
+    await manager.broadcast_json("end", "hand_list", read_all_hands(room_id, db), room_id)
     await manager.broadcast_json("end", "game_list", read_game(room_id, db), room_id)
     await manager.close_with_room_id(room_id)
 

--- a/sql_app/main.py
+++ b/sql_app/main.py
@@ -164,7 +164,7 @@ async def websocket_endpoint(websocket: WebSocket, affiliation: str, name: str, 
         await ConnectionManager.send_json("join", "success", "game", game.dict(include={'room_id', 'person_id'}), websocket)
         # 해당 방 전체에게 전적(사람) 목록 반환 응답
         await manager.broadcast_json("join", 'game_list', read_game(room.id, db), room.id)
-        asyncio.run(after_join(websocket, person.id, room.id, db))
+        await after_join(websocket, person.id, room.id, db)
 
     except WebSocketDisconnect:
         """

--- a/sql_app/main.py
+++ b/sql_app/main.py
@@ -75,7 +75,8 @@ class ConnectionManager:
         # 한 방 전체의 사람들을 퇴장시킴
         for connection in self.find_all_connections_by_room_id(room_id):
             await connection[0].close()
-            self.active_connections.remove(connection)
+            if connection in self.active_connections:
+                self.active_connections.remove(connection)
 
     """
     async def send_personal_json(self, message: dict, websocket: WebSocket):

--- a/sql_app/main.py
+++ b/sql_app/main.py
@@ -1,10 +1,11 @@
 from typing import List, Tuple
 
-from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect, BackgroundTasks
 #from fastapi.security import OAuth2PasswordBearer
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from pytz import timezone
+import asyncio
 
 from . import crud, models, schemas
 from .database import SessionLocal, engine
@@ -85,12 +86,12 @@ class ConnectionManager:
     """
 
     async def send_text(request: str, response: str, message: str, websocket: WebSocket):
-        text = {}
-        text["request"] = request
-        text["response"] = response
-        text["type"] = "message"
-        text["message"] = message
-        await websocket.send_json(text, mode=JSON_SENDING_MODE)
+        obj = {}
+        obj["request"] = request
+        obj["response"] = response
+        obj["type"] = "message"
+        obj["message"] = message
+        await websocket.send_json(obj, mode=JSON_SENDING_MODE)
 
     async def send_json(request: str, response: str, type: str, data: dict or list, websocket: WebSocket):
         obj = {}
@@ -107,6 +108,16 @@ class ConnectionManager:
         obj["response"] = "broadcast"
         obj["type"] = type
         obj["data"] = data
+        for connection in self.find_all_connections_by_room_id(room_id):
+            await connection[0].send_json(obj, mode=JSON_SENDING_MODE)
+
+    async def broadcast_text(self, request: str, message: str, room_id: int):
+        # 한 방 전체의 사람들에게 공통된 JSON을 보냄
+        obj = {}
+        obj["request"] = request
+        obj["response"] = "broadcast"
+        obj["type"] = "message"
+        obj["message"] = message
         for connection in self.find_all_connections_by_room_id(room_id):
             await connection[0].send_json(obj, mode=JSON_SENDING_MODE)
 
@@ -153,88 +164,7 @@ async def websocket_endpoint(websocket: WebSocket, affiliation: str, name: str, 
         await ConnectionManager.send_json("join", "success", "game", game.dict(include={'room_id', 'person_id'}), websocket)
         # 해당 방 전체에게 전적(사람) 목록 반환 응답
         await manager.broadcast_json("join", 'game_list', read_game(room.id, db), room.id)
-        while True:
-            # 클라이언트의 요청 대기
-            data = await websocket.receive_json(mode=JSON_RECEIVING_MODE)
-
-            if data["request"] == "hand":
-                # 손 입력 요청
-                # 해당 방에 새로운 손 추가
-                _, error_code = crud.create_hand(db, room_id=room.id, person_id=person.id, hand=data["hand"])
-                if error_code == 0:
-                    await manager.broadcast_json("hand", "hand_list", read_all_hands(room.id, db), room.id)
-                    await manager.broadcast_json("hand", "game_list", read_game(room.id, db), room.id)
-                elif error_code == 1 or error_code == 11:
-                    await ConnectionManager.send_text("hand", "error", "Room is not in a play mode", websocket)
-                    #raise HTTPException(status_code=400, detail="Room is not in a play mode")
-                elif error_code == 2 or error_code == 12:
-                    await ConnectionManager.send_text("hand", "error", "Game not started yet", websocket)
-                    #raise HTTPException(status_code=403, detail="Game not started yet")
-                elif error_code == 3 or error_code == 13:
-                    await ConnectionManager.send_text("hand", "error", "Person not found", websocket)
-                    #raise HTTPException(status_code=404, detail="Person not found")
-                elif error_code == 4:
-                    await ConnectionManager.send_text("hand", "error", "Initial hand not found", websocket)
-                    #raise HTTPException(status_code=500, detail="Initial hand not found")
-                elif error_code == 5 or error_code == 15:
-                    await ConnectionManager.send_text("hand", "error", "Room not found", websocket)
-                    #raise HTTPException(status_code=404, detail="Room not found")
-                elif error_code == 6 or error_code == 16:
-                    await ConnectionManager.send_text("hand", "error", "Game has ended", websocket)
-                    #raise HTTPException(status_code=403, detail="Game has ended")
-                    
-            elif data["request"] == "quit":
-                # 나가기 요청
-                # 대기 중인 방일 경우에, 해당 방에 해당 사람이 있으면 제거
-                _, error_code = crud.update_room_to_quit(db, room.id, person.id)
-                if error_code == 0:
-                    await ConnectionManager.send_text("quit", "success", "Successfully signed out", websocket)
-                    await manager.close(websocket)
-                    await manager.broadcast_json("quit", "game_list", read_game(room.id, db), room.id)
-                    return
-                elif error_code == 1:
-                    await ConnectionManager.send_text("quit", "error", "Room not found", websocket)
-                    #raise HTTPException(status_code=404, detail="Room not found")
-                elif error_code == 2:
-                    await ConnectionManager.send_text("quit", "error", "Cannot quit from non-wait Room", websocket)
-                    #raise HTTPException(status_code=403, detail="Cannot quit from non-wait Room")
-                elif error_code == 3:
-                    await ConnectionManager.send_text("quit", "error", "Person not found", websocket)
-                    #raise HTTPException(status_code=404, detail="Person not found")
-                elif error_code == 4:
-                    await ConnectionManager.send_text("quit", "error", "Person does not exist in the Room", websocket)
-                    #raise HTTPException(status_code=404, detail="Person does not exist in the Room")
-                
-            elif data["request"] == "start":
-                # 게임 시작 요청
-
-                # 해당 방의 상태 변경
-                # 시작 후 time_offset 초 후부터 time_duration 초 동안 손 입력을 받음
-                db_room = read_room(room.id, db)
-                if db_room is None:
-                    await ConnectionManager.send_text("start", "error", "Room not found", websocket)
-                    #raise HTTPException(status_code=404, detail="Room not found")
-
-                if db_room["state"] == schemas.RoomStateEnum.Wait:
-                    room = crud.update_room_to_play(db, room_id=room.id, \
-                        time_offset=data["time_offset"], time_duration=data["time_duration"])
-                else:
-                    await ConnectionManager.send_text("start", "error", "Room is not in a wait mode", websocket)
-                await manager.broadcast_json("start", "room", read_room(room.id, db), room.id)
-                await manager.broadcast_json("start", "hand_list", read_all_hands(room.id, db), room.id)
-                await manager.broadcast_json("start", "game_list", read_game(room.id, db), room.id)
-
-            # 게임이 시간이 끝나 종료될 때를 처리해 주어야 함
-            # 내가 접속한 방은 동시에 하나만 존재하므로, 해당 방에 대해 시간이 끝났는지 확인하고,
-            # 끝났다면 해당 개인에게 응답을 보내고 연결 종료
-
-            # 아직 플레이 시간이 종료되지 않았거나 이미 종료 상태가 된 방이면 아무 일도 일어나지 않음
-            crud.update_room_to_end(db, room.id)
-            db_room = crud.get_room(db, room.id)
-            if db_room is not None and db_room.state == schemas.RoomStateEnum.End:
-                await ConnectionManager.send_json("end", "broadcast", "game_list", read_game(room.id, db), room.id)
-                await manager.close(websocket)
-                return
+        asyncio.run(after_join(websocket, person.id, room.id, db))
 
     except WebSocketDisconnect:
         """
@@ -295,18 +225,30 @@ def read_room(room_id: int, db: Session = Depends(get_db)):
         return None
         #raise HTTPException(status_code=404, detail="Room not found")
     
-    if db_room.start_time is None or db_room.end_time is None:
-        return {
-            'state': db_room.state,
-            'start_time': "",
-            'end_time': ""
-        }
-    else:
-        return {
-            'state': db_room.state,
-            'start_time': db_room.start_time.astimezone(timezone('Asia/Seoul')).strftime("%Y-%m-%d %H:%M:%S.%f %Z"),
-            'end_time': db_room.end_time.astimezone(timezone('Asia/Seoul')).strftime("%Y-%m-%d %H:%M:%S.%f %Z")
-        }
+    to = -1
+    td = -1
+    it = ""
+    st = ""
+    et = ""
+    if db_room.time_offset is not None:
+        to = db_room.time_offset
+    if db_room.time_duration is not None:
+        td = db_room.time_duration
+    if db_room.init_time is not None:
+        it = db_room.init_time.astimezone(timezone('Asia/Seoul')).strftime("%Y-%m-%d %H:%M:%S.%f %Z")
+    if db_room.start_time is not None:
+        st = db_room.init_time.astimezone(timezone('Asia/Seoul')).strftime("%Y-%m-%d %H:%M:%S.%f %Z")
+    if db_room.end_time is not None:
+        et = db_room.init_time.astimezone(timezone('Asia/Seoul')).strftime("%Y-%m-%d %H:%M:%S.%f %Z")
+
+    return {
+        'state': db_room.state,
+        "time_offset" : to,
+        "time_duration" : td,
+        'init_time': it,
+        'start_time': st,
+        'end_time': et
+    }
 
 """
 @app.delete("/room/{room_id}")
@@ -324,7 +266,7 @@ def delete_person_from_room(room_id: int, person_id: int, db: Session = Depends(
     elif error_code == 4:
         raise HTTPException(status_code=404, detail="Person does not exist in the Room")
 """
-
+"""
 @app.get("/room/{room_id}/persons")
 def read_number_of_persons(room_id: int, db: Session = Depends(get_db)):
     # 해당 방의 사람 수(int) 반환
@@ -333,7 +275,7 @@ def read_number_of_persons(room_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Room not found")
     
     return len(db_room.persons)
-
+"""
 """
 @app.put("/room/{room_id}/play")
 def update_room_to_play(room_id: int, time_offset: int = 5, \
@@ -479,3 +421,101 @@ def read_all_games(db: Session = Depends(get_db)):
     # (디버깅 용도)
     return crud.get_games(db)
 """
+
+# 코루틴을 활용하여 방의 게임 시간을 관리
+# 하나의 방이 Playing 상태로 바뀔 때(start 요청을 받을 때) asyncio task를 생성하여 예약한 시간만큼 기다린다.
+# 입력을 받기 시작할 때 한 번 broadcast로 메시지를 보내고, 게임이 종료될 때 한 번 더 broadcast로 메시지를 보낸다.
+# broadcast를 보내는 동안에는 함수를 blocking하지 않는다. 즉, broadcast 시간이 늦어져도 총 게임 시간에는 영향을 주지 않는다.
+async def manage_time_for_room(room_id: int, time_offset: int, time_duration: int, db: Session = Depends(get_db)):
+    if time_offset < 0:
+        time_offset = 0
+    if time_duration < 1:
+        time_duration = 1
+
+    task1 = asyncio.create_task(manager.broadcast_json("start", "room", read_room(room_id, db), room_id))
+    task2 = asyncio.create_task(manager.broadcast_json("start", "hand_list", read_all_hands(room_id, db), room_id))
+    task3 = asyncio.create_task(manager.broadcast_json("start", "game_list", read_game(room_id, db), room_id))
+    task4 = asyncio.create_task(asyncio.sleep(time_offset))
+    await task1
+    await task2
+    await task3
+    await task4
+    
+    crud.update_room_to_start(db, room_id)
+    task1 = asyncio.create_task(manager.broadcast_text('start', "Game start", room_id))
+    task2 = asyncio.create_task(asyncio.sleep(time_duration))
+    await task1
+    await task2
+    crud.update_room_to_end(db, room_id)  # 백엔드 자체에서 시간으로 입력 가능 여부를 판단하면 안 되고, 함수를 호출한 순간 무조건 Ending 페이즈로 변경해야 한다.
+    await manager.broadcast_json("end", "game_list", read_game(room_id, db), room_id)
+    await manager.close_with_room_id(room_id)
+
+async def after_join(websocket: WebSocket, person_id: int, room_id: int, db: Session = Depends(get_db)):
+    while True:
+        # 클라이언트의 요청 대기
+        data = await websocket.receive_json(mode=JSON_RECEIVING_MODE)
+
+        if data["request"] == "hand":
+            # 손 입력 요청
+            # 해당 방에 새로운 손 추가
+            _, error_code = crud.create_hand(db, room_id=room_id, person_id=person_id, hand=data["hand"])
+            if error_code == 0:
+                await manager.broadcast_json("hand", "hand_list", read_all_hands(room_id, db), room_id)
+                await manager.broadcast_json("hand", "game_list", read_game(room_id, db), room_id)
+            elif error_code == 1 or error_code == 11:
+                await ConnectionManager.send_text("hand", "error", "Room is not in a play mode", websocket)
+                #raise HTTPException(status_code=400, detail="Room is not in a play mode")
+            elif error_code == 2 or error_code == 12:
+                await ConnectionManager.send_text("hand", "error", "Game not started yet", websocket)
+                #raise HTTPException(status_code=403, detail="Game not started yet")
+            elif error_code == 3 or error_code == 13:
+                await ConnectionManager.send_text("hand", "error", "Person not found", websocket)
+                #raise HTTPException(status_code=404, detail="Person not found")
+            elif error_code == 4:
+                await ConnectionManager.send_text("hand", "error", "Initial hand not found", websocket)
+                #raise HTTPException(status_code=500, detail="Initial hand not found")
+            elif error_code == 5 or error_code == 15:
+                await ConnectionManager.send_text("hand", "error", "Room not found", websocket)
+                #raise HTTPException(status_code=404, detail="Room not found")
+            elif error_code == 6 or error_code == 16:
+                await ConnectionManager.send_text("hand", "error", "Game has ended", websocket)
+                #raise HTTPException(status_code=403, detail="Game has ended")
+                
+        elif data["request"] == "quit":
+            # 나가기 요청
+            # 대기 중인 방일 경우에, 해당 방에 해당 사람이 있으면 제거
+            _, error_code = crud.update_room_to_quit(db, room_id, person_id)
+            if error_code == 0:
+                await ConnectionManager.send_text("quit", "success", "Successfully signed out", websocket)
+                await manager.close(websocket)
+                await manager.broadcast_json("quit", "game_list", read_game(room_id, db), room_id)
+                return
+            elif error_code == 1:
+                await ConnectionManager.send_text("quit", "error", "Room not found", websocket)
+                #raise HTTPException(status_code=404, detail="Room not found")
+            elif error_code == 2:
+                await ConnectionManager.send_text("quit", "error", "Cannot quit from non-wait Room", websocket)
+                #raise HTTPException(status_code=403, detail="Cannot quit from non-wait Room")
+            elif error_code == 3:
+                await ConnectionManager.send_text("quit", "error", "Person not found", websocket)
+                #raise HTTPException(status_code=404, detail="Person not found")
+            elif error_code == 4:
+                await ConnectionManager.send_text("quit", "error", "Person does not exist in the Room", websocket)
+                #raise HTTPException(status_code=404, detail="Person does not exist in the Room")
+            
+        elif data["request"] == "start":
+            # 게임 시작 요청
+
+            # 해당 방의 상태 변경
+            # 시작 후 time_offset 초 후부터 time_duration 초 동안 손 입력을 받음
+            db_room = read_room(room_id, db)
+            if db_room is None:
+                await ConnectionManager.send_text("start", "error", "Room not found", websocket)
+                #raise HTTPException(status_code=404, detail="Room not found")
+
+            if db_room["state"] == schemas.RoomStateEnum.Wait:
+                room = crud.update_room_to_play(db, room_id=room_id, \
+                    time_offset=data["time_offset"], time_duration=data["time_duration"])
+                asyncio.create_task(manage_time_for_room(room_id, time_offset=data["time_offset"], time_duration=data["time_duration"], db=db))
+            else:
+                await ConnectionManager.send_text("start", "error", "Room is not in a wait mode", websocket)

--- a/sql_app/main.py
+++ b/sql_app/main.py
@@ -202,7 +202,7 @@ def read_root():
 @app.get("/connections")
 def read_connections():
     # (디버깅 용도)
-    return {"connections": manager.active_connections}
+    return {"connections": json.dumps(manager.active_connections)}
 
 @app.get("/room/list", response_model=List[schemas.Room])
 def read_all_room(db: Session = Depends(get_db)):

--- a/sql_app/main.py
+++ b/sql_app/main.py
@@ -202,7 +202,10 @@ def read_root():
 @app.get("/connections")
 def read_connections():
     # (디버깅 용도)
-    return {"connections": json.dumps(manager.active_connections)}
+    ret = []
+    for con in manager.active_connections:
+        ret.append({'room_id': con[2], 'person_id': con[1]})
+    return {"connections": ret}
 
 @app.get("/room/list", response_model=List[schemas.Room])
 def read_all_room(db: Session = Depends(get_db)):

--- a/sql_app/models.py
+++ b/sql_app/models.py
@@ -27,6 +27,9 @@ class Room(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True, index=True)
     state = Column(Enum(RoomStateEnum), default=RoomStateEnum.Wait)
+    time_offset = Column(Integer, nullable=True)
+    time_duration = Column(Integer, nullable=True)
+    init_time = Column(DateTime(timezone=True), nullable=True)
     start_time = Column(DateTime(timezone=True), nullable=True)
     end_time = Column(DateTime(timezone=True), nullable=True)
 

--- a/sql_app/schemas.py
+++ b/sql_app/schemas.py
@@ -73,10 +73,13 @@ class RoomCreate(RoomBase):
 
 class Room(RoomBase):
     id: int
+    time_offset: Union[int, None] = None
+    time_duration: Union[int, None] = None
+    init_time: Union[datetime, None] = None
     start_time: Union[datetime, None] = None
     end_time: Union[datetime, None] = None
     persons: List[Game] = []
-    #games: List[Game] = []
+    games: List[Game] = []
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## 주요 변경사항
* 방이 플레이 상태가 된 후 설정된 시간이 지나면 비동기적이며 자동적으로 게임이 종료된 상태가 되고 방 안에 있던 모든 사람들을 퇴장시킵니다! 😎
  * 프론트엔드에서는 그냥 끝나는 응답(`response: "end"`)이 올 때까지 게임을 진행하면 됩니다!
* "start" 관련 요청에서 반환되는 응답 API가 변경되었습니다.
  * `type: "room"`인 응답에서 `data`에 포함되는 attributes가 달라졌어요! `start_time`과 `end_time`은 각각 그 시간이 지나기 전까지는 빈 문자열(`""`)을 반환하고, 시간이 지나면 시간 정보(예: `"2022-12-25 03:24:05.388157 KST"`)를 반환합니다.
  * 이제 설정한 `time_offset`초가 지나 손 입력을 받기 시작하는 순간에 서버에서 자동으로 해당 방의 모든 사람들에게 아래 응답을 보냅니다.
```
{
  request: "start",
  response: "broadcast",
  type: "message",
  message: "Game start"
}
```
* 백엔드 API 테스트 코드로 테스트를 완료하였습니다!
  * README.md의 맨 뒤에 테스트 로그를 첨부하였습니다.

### 참고
* `asyncio_test.py`는 비동기 함수들의 작동 원리를 파악하기 위해 테스트 용도로 넣은 코드이고, 빼더라도 실행에 아무런 지장이 없습니다.